### PR TITLE
feat: introduce world map and battle scenes

### DIFF
--- a/src/game/main.js
+++ b/src/game/main.js
@@ -5,6 +5,10 @@ import { MainMenu } from './scenes/MainMenu';
 import { Preloader } from './scenes/Preloader';
 import { AUTO, Game } from 'phaser';
 
+//  Newly added game scenes.
+import { WorldMap } from './scenes/WorldMap';
+import { BattleScene } from './scenes/BattleScene';
+
 //  Find out more information about the Game Config at:
 //  https://docs.phaser.io/api-documentation/typedef/types-core#gameconfig
 const config = {
@@ -22,7 +26,10 @@ const config = {
         Preloader,
         MainMenu,
         MainGame,
-        GameOver
+        GameOver,
+        //  Enable exploration and battles via the new scenes.
+        WorldMap,
+        BattleScene
     ]
 };
 

--- a/src/game/scenes/BattleScene.js
+++ b/src/game/scenes/BattleScene.js
@@ -1,0 +1,40 @@
+import { Scene } from 'phaser';
+
+export class BattleScene extends Scene
+{
+    constructor ()
+    {
+        super('BattleScene');
+    }
+
+    preload ()
+    {
+        //  Preload battle scene assets here.
+        //  Example: this.load.image('battle-background', 'assets/images/battle/battle-stage-arena.png');
+    }
+
+    create ()
+    {
+        //  Add the battle background image.
+        //  this.add.image(512, 384, 'battle-background');
+
+        this.add.text(512, 384, '\uC5EC\uAE30\uB294 \uC804\uD22C \uC2E4\uD5D8\uC785\uB2C8\uB2E4.', {
+            fontFamily: 'Arial Black',
+            fontSize: 48,
+            color: '#ffffff',
+            stroke: '#000000',
+            strokeThickness: 8,
+            align: 'center'
+        }).setOrigin(0.5);
+
+        //  Pressing the 'M' key returns to the world map.
+        this.input.keyboard.on('keydown-M', () => {
+            this.scene.start('WorldMap');
+        });
+    }
+
+    update (time, delta)
+    {
+        //  Implement core battle logic that needs to run each frame here.
+    }
+}

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -40,7 +40,7 @@ export class Preloader extends Scene
         //  When all the assets have loaded, it's often worth creating global objects here that the rest of the game can use.
         //  For example, you can define global animations here, so we can use them in other scenes.
 
-        //  Move to the MainMenu. You could also swap this for a Scene Transition, such as a camera fade.
-        this.scene.start('MainMenu');
+        //  Start the adventure on the world map instead of the main menu.
+        this.scene.start('WorldMap');
     }
 }

--- a/src/game/scenes/WorldMap.js
+++ b/src/game/scenes/WorldMap.js
@@ -1,0 +1,52 @@
+import { Scene } from 'phaser';
+
+export class WorldMap extends Scene
+{
+    constructor ()
+    {
+        super('WorldMap');
+    }
+
+    preload ()
+    {
+        //  Preload assets required for the world map scene here.
+        //  Example: this.load.image('world-map-background', 'assets/images/territory/cursed-forest.png');
+    }
+
+    create ()
+    {
+        //  Add the world map background to the scene.
+        //  this.add.image(0, 0, 'world-map-background').setOrigin(0);
+
+        this.add.text(512, 384, '\uC5EC\uAE30\uB294 \uC6D4\uB4DC\uB9F5\uC785\uB2C8\uB2E4.', {
+            fontFamily: 'Arial Black',
+            fontSize: 48,
+            color: '#ffffff',
+            stroke: '#000000',
+            strokeThickness: 8,
+            align: 'center'
+        }).setOrigin(0.5);
+
+        //  Enable dragging the camera around the map.
+        this.cameras.main.setBounds(0, 0, 1920, 1080);
+        this.input.on('pointermove', (pointer) => {
+            if (!pointer.isDown)
+            {
+                return;
+            }
+
+            this.cameras.main.scrollX -= (pointer.x - pointer.prevPosition.x) / this.cameras.main.zoom;
+            this.cameras.main.scrollY -= (pointer.y - pointer.prevPosition.y) / this.cameras.main.zoom;
+        });
+
+        //  Pressing the 'B' key switches to the battle scene.
+        this.input.keyboard.on('keydown-B', () => {
+            this.scene.start('BattleScene');
+        });
+    }
+
+    update (time, delta)
+    {
+        //  Handle world map logic that needs to run each frame here.
+    }
+}


### PR DESCRIPTION
## Summary
- add exploratory WorldMap scene with camera drag and battle transition
- add BattleScene allowing return to world map
- register new scenes and start game at the world map

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68974dd958848327bc7fdbe63512501b