### PR TITLE
Fix asset paths for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="style.css">
     <title>Phaser - Template</title>
 </head>
 
@@ -15,3 +15,4 @@
     <script type="module" src="src/main.js"></script>
 </body>
 </html>
+

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -1,13 +1,13 @@
-import { Boot } from './scenes/Boot';
-import { Game as MainGame } from './scenes/Game';
-import { GameOver } from './scenes/GameOver';
-import { MainMenu } from './scenes/MainMenu';
-import { Preloader } from './scenes/Preloader';
+import { Boot } from './scenes/Boot.js';
+import { Game as MainGame } from './scenes/Game.js';
+import { GameOver } from './scenes/GameOver.js';
+import { MainMenu } from './scenes/MainMenu.js';
+import { Preloader } from './scenes/Preloader.js';
 import { AUTO, Game } from 'phaser';
 
 //  Newly added game scenes.
-import { WorldMap } from './scenes/WorldMap';
-import { BattleScene } from './scenes/BattleScene';
+import { WorldMap } from './scenes/WorldMap.js';
+import { BattleScene } from './scenes/BattleScene.js';
 
 //  Find out more information about the Game Config at:
 //  https://docs.phaser.io/api-documentation/typedef/types-core#gameconfig
@@ -40,3 +40,4 @@ const StartGame = (parent) => {
 }
 
 export default StartGame;
+

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import StartGame from './game/main';
+import StartGame from './game/main.js';
 
 document.addEventListener('DOMContentLoaded', () => {
 


### PR DESCRIPTION
## Summary
- use relative path for style.css so GitHub Pages can find it
- include explicit .js extensions in main modules

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689750565c888327aad07d8e3c314f1e