### PR TITLE
Add player data and battlefield movement

### DIFF
--- a/src/data/units.js
+++ b/src/data/units.js
@@ -1,0 +1,10 @@
+// 유닛들의 기본 정보를 정의하는 파일입니다.
+export const PLAYER = {
+    key: 'player', // 유닛을 식별하는 고유 키
+    image: 'assets/images/unit/warrior.png', // 사용할 이미지 경로
+    name: '전사', // 유닛 이름
+    speed: 200 // 유닛의 이동 속도
+};
+
+// 나중에 다른 유닛들도 여기에 추가할 수 있습니다.
+// export const GOBLIN = { ... };

--- a/src/game/scenes/BattleScene.js
+++ b/src/game/scenes/BattleScene.js
@@ -1,40 +1,50 @@
 import { Scene } from 'phaser';
+import { PLAYER } from '../../data/units.js'; // 우리가 만든 유닛 데이터 불러오기
 
-export class BattleScene extends Scene
-{
-    constructor ()
-    {
+export class BattleScene extends Scene {
+    constructor() {
         super('BattleScene');
+        
+        this.player = null; // 플레이어 객체를 담을 변수
+        this.cursors = null; // 키보드 입력 객체를 담을 변수
     }
 
-    preload ()
-    {
-        //  Preload battle scene assets here.
-        //  Example: this.load.image('battle-background', 'assets/images/battle/battle-stage-arena.png');
-    }
+    create() {
+        // 1. 배경 이미지 추가
+        this.add.image(512, 384, 'battle-background');
 
-    create ()
-    {
-        //  Add the battle background image.
-        //  this.add.image(512, 384, 'battle-background');
+        // 2. 플레이어 생성
+        // 물리 엔진이 적용된 스프라이트로 생성하여 움직임을 처리합니다.
+        // 'player'는 Preloader에서 지정한 이미지 키입니다.
+        this.player = this.physics.add.sprite(512, 384, PLAYER.key);
 
-        this.add.text(512, 384, '\uC5EC\uAE30\uB294 \uC804\uD22C \uC2E4\uD5D8\uC785\uB2C8\uB2E4.', {
-            fontFamily: 'Arial Black',
-            fontSize: 48,
-            color: '#ffffff',
-            stroke: '#000000',
-            strokeThickness: 8,
-            align: 'center'
-        }).setOrigin(0.5);
+        // 3. 입력 시스템 초기화
+        // Phaser가 기본으로 제공하는 키보드 입력 시스템을 사용합니다.
+        // 따로 '인풋 매니저'를 만들 필요가 없습니다.
+        this.cursors = this.input.keyboard.createCursorKeys();
 
-        //  Pressing the 'M' key returns to the world map.
+        // 4. 월드맵으로 돌아가는 키
         this.input.keyboard.on('keydown-M', () => {
             this.scene.start('WorldMap');
         });
     }
 
-    update (time, delta)
-    {
-        //  Implement core battle logic that needs to run each frame here.
+    update(time, delta) {
+        // 매 프레임마다 실행되며, 여기서 플레이어의 움직임을 처리합니다.
+
+        // 이전 속도를 초기화하여 키를 뗐을 때 멈추도록 합니다.
+        this.player.setVelocity(0);
+
+        if (this.cursors.left.isDown) {
+            this.player.setVelocityX(-PLAYER.speed);
+        } else if (this.cursors.right.isDown) {
+            this.player.setVelocityX(PLAYER.speed);
+        }
+
+        if (this.cursors.up.isDown) {
+            this.player.setVelocityY(-PLAYER.speed);
+        } else if (this.cursors.down.isDown) {
+            this.player.setVelocityY(PLAYER.speed);
+        }
     }
 }

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -33,6 +33,11 @@ export class Preloader extends Scene
         this.load.setPath('assets');
 
         this.load.image('logo', 'logo.png');
+
+        // 월드맵과 전투씬 배경, 플레이어 이미지를 불러옵니다.
+        this.load.image('world-map-background', 'images/territory/cursed-forest.png');
+        this.load.image('battle-background', 'images/battle/battle-stage-arena.png');
+        this.load.image('player', 'images/unit/warrior.png'); // 'player'라는 키로 전사 이미지를 불러옵니다.
     }
 
     create ()

--- a/src/game/scenes/WorldMap.js
+++ b/src/game/scenes/WorldMap.js
@@ -15,15 +15,16 @@ export class WorldMap extends Scene
 
     create ()
     {
-        //  Add the world map background to the scene.
-        //  this.add.image(0, 0, 'world-map-background').setOrigin(0);
+        //  실제 월드맵 배경을 화면에 표시합니다.
+        this.add.image(0, 0, 'world-map-background').setOrigin(0);
 
-        this.add.text(512, 384, '\uC5EC\uAE30\uB294 \uC6D4\uB4DC\uB9F5\uC785\uB2C8\uB2E4.', {
+        //  전투로 들어가는 방법을 안내하는 텍스트를 추가합니다.
+        this.add.text(512, 700, '\uC774\uB3D9 \uD0A4\uC785\uB2C8\uB2E4. B \uD0A4\uB85C \uC804\uD22C\uB97C \uC2DC\uC791\uD558\uC138\uC694.', {
             fontFamily: 'Arial Black',
-            fontSize: 48,
+            fontSize: 32,
             color: '#ffffff',
             stroke: '#000000',
-            strokeThickness: 8,
+            strokeThickness: 6,
             align: 'center'
         }).setOrigin(0.5);
 


### PR DESCRIPTION
## Summary
- Define reusable PLAYER unit data
- Preload world map, battle background, and player images
- Render player in battle scene with arrow key movement
- Display world map background with instructions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689751fe4bb08327955e545378ad1e8b