### PR TITLE
Fix broken asset and Phaser imports for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="./public/style.css">
     <title>Phaser - Template</title>
 </head>
 

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -3,7 +3,9 @@ import { Game as MainGame } from './scenes/Game.js';
 import { GameOver } from './scenes/GameOver.js';
 import { MainMenu } from './scenes/MainMenu.js';
 import { Preloader } from './scenes/Preloader.js';
-import { AUTO, Game } from 'phaser';
+import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+
+const { AUTO, Game } = Phaser;
 
 //  Newly added game scenes.
 import { WorldMap } from './scenes/WorldMap.js';


### PR DESCRIPTION
## Summary
- fix stylesheet link to reference `public/style.css`
- load Phaser via CDN to avoid missing module errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68975374e4c48327b05655f3ce69b457