### PR TITLE
fix: resolve Phaser module via CDN

### DIFF
--- a/src/game/scenes/BattleScene.js
+++ b/src/game/scenes/BattleScene.js
@@ -1,4 +1,5 @@
-import { Scene } from 'phaser';
+// Reference Phaser via CDN so this scene can load without tooling.
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 import { PLAYER } from '../../data/units.js'; // 우리가 만든 유닛 데이터 불러오기
 
 export class BattleScene extends Scene {

--- a/src/game/scenes/Boot.js
+++ b/src/game/scenes/Boot.js
@@ -1,4 +1,5 @@
-import { Scene } from 'phaser';
+// Load Phaser directly from a CDN so the game can run without a bundler.
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 
 export class Boot extends Scene
 {

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -1,4 +1,5 @@
-import { Scene } from 'phaser';
+// Import Phaser's Scene from a CDN so this module works standalone.
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 
 export class Game extends Scene
 {

--- a/src/game/scenes/GameOver.js
+++ b/src/game/scenes/GameOver.js
@@ -1,4 +1,5 @@
-import { Scene } from 'phaser';
+// Pull Scene from Phaser via CDN to keep the module self-contained.
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 
 export class GameOver extends Scene
 {

--- a/src/game/scenes/MainMenu.js
+++ b/src/game/scenes/MainMenu.js
@@ -1,4 +1,5 @@
-import { Scene } from 'phaser';
+// Use Phaser from a CDN so the project can run in the browser without bundling.
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 
 export class MainMenu extends Scene
 {

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -1,4 +1,5 @@
-import { Scene } from 'phaser';
+// Use the CDN version of Phaser to avoid module resolution issues.
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 
 export class Preloader extends Scene
 {

--- a/src/game/scenes/WorldMap.js
+++ b/src/game/scenes/WorldMap.js
@@ -1,4 +1,5 @@
-import { Scene } from 'phaser';
+// Load Phaser's Scene from a CDN for better portability.
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 
 export class WorldMap extends Scene
 {


### PR DESCRIPTION
## Summary
- load Phaser from CDN in every scene module to avoid failed module resolution

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689791e1f4c48327a8507322886852d6