### PR TITLE
Enable Arcade physics for battle scene

### DIFF
--- a/src/game/main.js
+++ b/src/game/main.js
@@ -23,6 +23,13 @@ const config = {
         mode: Phaser.Scale.FIT,
         autoCenter: Phaser.Scale.CENTER_BOTH
     },
+    physics: {
+        default: 'arcade',
+        arcade: {
+            gravity: { y: 0 },
+            debug: false
+        }
+    },
     scene: [
         Boot,
         Preloader,


### PR DESCRIPTION
## Summary
- enable Phaser Arcade physics in game configuration so BattleScene can create physics-driven sprites

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6897963815708327be935f0654e5963e