### PR TITLE
Add basic melee AI and integrate into battle scene

### DIFF
--- a/src/ai/meleeAI.js
+++ b/src/ai/meleeAI.js
@@ -1,0 +1,99 @@
+import Phaser from 'phaser';
+
+// 행동 트리의 기본 노드 상태
+const NodeStatus = {
+    SUCCESS: 'SUCCESS',
+    FAILURE: 'FAILURE',
+    RUNNING: 'RUNNING',
+};
+
+// 기본 노드 클래스 (모든 노드들의 부모)
+class BehaviorNode {
+    execute(owner, target) {
+        throw new Error("실행 메소드가 구현되지 않았습니다.");
+    }
+}
+
+// Sequence 노드: 모든 자식이 성공해야 성공
+class Sequence extends BehaviorNode {
+    constructor(nodes) {
+        super();
+        this.nodes = nodes;
+    }
+
+    execute(owner, target) {
+        for (const node of this.nodes) {
+            if (node.execute(owner, target) === NodeStatus.FAILURE) {
+                return NodeStatus.FAILURE;
+            }
+        }
+        return NodeStatus.SUCCESS;
+    }
+}
+
+// --- AI를 위한 실제 노드들 ---
+
+// 조건 노드: 플레이어가 추격 범위 안에 있는지 확인
+class IsPlayerInChaseRange extends BehaviorNode {
+    constructor(range) {
+        super();
+        this.range = range;
+    }
+
+    execute(owner, target) {
+        // owner(적)와 target(플레이어) 사이의 거리를 계산
+        const distance = Phaser.Math.Distance.Between(owner.x, owner.y, target.x, target.y);
+        
+        if (distance <= this.range) {
+            console.log('플레이어 발견! 추격 시작.');
+            return NodeStatus.SUCCESS; // 범위 안이면 성공
+        }
+        return NodeStatus.FAILURE; // 범위 밖이면 실패
+    }
+}
+
+// 행동 노드: 플레이어를 향해 이동
+class MoveToPlayer extends BehaviorNode {
+    execute(owner, target) {
+        // 물리 엔진을 사용하여 target(플레이어) 방향으로 owner(적)를 이동시킴
+        // owner.scene은 현재 씬(BattleScene)에 접근하기 위함입니다.
+        owner.scene.physics.moveToObject(owner, target, owner.speed);
+        return NodeStatus.SUCCESS;
+    }
+}
+
+// 행동 노드: 정지
+class StopMovement extends BehaviorNode {
+    execute(owner) {
+        owner.setVelocity(0, 0);
+        return NodeStatus.SUCCESS;
+    }
+}
+
+
+// --- 실제 MeleeAI 클래스 ---
+export class MeleeAI {
+    constructor(owner, target) {
+        this.owner = owner;   // 이 AI를 사용하는 적 캐릭터
+        this.target = target; // 공격 대상 (플레이어)
+        
+        // AI의 행동 트리 구조를 정의합니다.
+        this.root = new Sequence([
+            new IsPlayerInChaseRange(300), // 300픽셀 범위 안에 들어오면
+            new MoveToPlayer()             // 플레이어를 향해 이동한다
+        ]);
+
+        // 추격 범위 밖에 있을 때를 위한 대체 행동
+        this.idleBehavior = new StopMovement();
+    }
+
+    update() {
+        // 매 프레임마다 행동 트리의 최상단(root)부터 실행
+        const result = this.root.execute(this.owner, this.target);
+
+        // 만약 행동 트리가 실패했다면 (플레이어가 범위 밖에 있다면)
+        if (result === NodeStatus.FAILURE) {
+            this.idleBehavior.execute(this.owner); // 정지 행동을 실행
+        }
+    }
+}

--- a/src/data/units.js
+++ b/src/data/units.js
@@ -1,10 +1,9 @@
 // 유닛들의 기본 정보를 정의하는 파일입니다.
-export const PLAYER = {
-    key: 'player', // 유닛을 식별하는 고유 키
-    image: 'assets/images/unit/warrior.png', // 사용할 이미지 경로
-    name: '전사', // 유닛 이름
-    speed: 200 // 유닛의 이동 속도
+export const UNITS = {
+    WARRIOR: {
+        key: 'player', // 사용할 스프라이트 키 (현재 전사 이미지)
+        image: 'assets/images/unit/warrior.png', // 사용할 이미지 경로
+        name: '전사', // 유닛 이름
+        speed: 200 // 유닛의 이동 속도
+    }
 };
-
-// 나중에 다른 유닛들도 여기에 추가할 수 있습니다.
-// export const GOBLIN = { ... };

--- a/src/game/scenes/BattleScene.js
+++ b/src/game/scenes/BattleScene.js
@@ -1,51 +1,50 @@
-// Reference Phaser via CDN so this scene can load without tooling.
-import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
-import { PLAYER } from '../../data/units.js'; // 우리가 만든 유닛 데이터 불러오기
+import { Scene } from 'phaser';
+import { UNITS } from '../../data/units.js';
+import { MeleeAI } from '../../ai/meleeAI.js'; // 우리가 만든 AI 클래스 불러오기
 
 export class BattleScene extends Scene {
     constructor() {
         super('BattleScene');
-        
-        this.player = null; // 플레이어 객체를 담을 변수
-        this.cursors = null; // 키보드 입력 객체를 담을 변수
+        this.player = null;
+        this.enemy = null;
+        this.enemyAI = null; // 적군 AI 인스턴스를 담을 변수
+        this.cursors = null;
     }
 
     create() {
-        // 1. 배경 이미지 추가
         this.add.image(512, 384, 'battle-background');
 
-        // 2. 플레이어 생성
-        // 물리 엔진이 적용된 스프라이트로 생성하여 움직임을 처리합니다.
-        // 'player'는 Preloader에서 지정한 이미지 키입니다.
-        this.player = this.physics.add.sprite(512, 384, PLAYER.key);
+        this.player = this.physics.add.sprite(200, 384, UNITS.WARRIOR.key);
+        this.enemy = this.physics.add.sprite(824, 384, UNITS.WARRIOR.key);
+        this.enemy.setFlipX(true);
+        
+        // 적 캐릭터의 스탯을 데이터에서 직접 가져와 설정합니다.
+        // 나중에 캐릭터마다 다른 AI나 스탯을 적용하기 용이합니다.
+        this.enemy.speed = UNITS.WARRIOR.speed;
 
-        // 3. 입력 시스템 초기화
-        // Phaser가 기본으로 제공하는 키보드 입력 시스템을 사용합니다.
-        // 따로 '인풋 매니저'를 만들 필요가 없습니다.
+        // 적 AI를 생성하고, 주인(enemy)과 목표(player)를 알려줍니다.
+        this.enemyAI = new MeleeAI(this.enemy, this.player);
+
         this.cursors = this.input.keyboard.createCursorKeys();
 
-        // 4. 월드맵으로 돌아가는 키
         this.input.keyboard.on('keydown-M', () => {
             this.scene.start('WorldMap');
         });
     }
 
     update(time, delta) {
-        // 매 프레임마다 실행되며, 여기서 플레이어의 움직임을 처리합니다.
-
-        // 이전 속도를 초기화하여 키를 뗐을 때 멈추도록 합니다.
+        // 1. 플레이어 움직임 처리
+        const speed = UNITS.WARRIOR.speed;
         this.player.setVelocity(0);
+        if (this.cursors.left.isDown) this.player.setVelocityX(-speed);
+        else if (this.cursors.right.isDown) this.player.setVelocityX(speed);
+        if (this.cursors.up.isDown) this.player.setVelocityY(-speed);
+        else if (this.cursors.down.isDown) this.player.setVelocityY(speed);
 
-        if (this.cursors.left.isDown) {
-            this.player.setVelocityX(-PLAYER.speed);
-        } else if (this.cursors.right.isDown) {
-            this.player.setVelocityX(PLAYER.speed);
-        }
-
-        if (this.cursors.up.isDown) {
-            this.player.setVelocityY(-PLAYER.speed);
-        } else if (this.cursors.down.isDown) {
-            this.player.setVelocityY(PLAYER.speed);
+        // 2. 적 AI 업데이트
+        // 매 프레임 AI의 update()를 호출하여 스스로 판단하고 행동하게 합니다.
+        if (this.enemyAI) {
+            this.enemyAI.update();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Implement behavior-tree driven melee AI for chasing the player or idling
- Apply MeleeAI in BattleScene for enemy movement and control player movement
- Consolidate unit stats under `UNITS.WARRIOR`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6898c5fe8e6c83279df31d17937ef414