### PR TITLE
fix phaser module specifiers

### DIFF
--- a/src/ai/meleeAI.js
+++ b/src/ai/meleeAI.js
@@ -1,4 +1,4 @@
-import Phaser from 'phaser';
+import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 
 // 행동 트리의 기본 노드 상태
 const NodeStatus = {

--- a/src/game/scenes/BattleScene.js
+++ b/src/game/scenes/BattleScene.js
@@ -1,4 +1,4 @@
-import { Scene } from 'phaser';
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 import { UNITS } from '../../data/units.js';
 import { MeleeAI } from '../../ai/meleeAI.js';
 


### PR DESCRIPTION
## Summary
- fix missing Phaser imports by referencing CDN modules
- unify scene and AI modules around CDN Phaser path

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898c93a0a288327a785ac36f7415b3c