### PR TITLE
feat: add basic combat engine and unit system

### DIFF
--- a/src/ai/meleeAI.js
+++ b/src/ai/meleeAI.js
@@ -1,4 +1,4 @@
-import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import Phaser from 'phaser';
 
 // 행동 트리의 기본 노드 상태
 const NodeStatus = {
@@ -57,7 +57,7 @@ class MoveToPlayer extends BehaviorNode {
     execute(owner, target) {
         // 물리 엔진을 사용하여 target(플레이어) 방향으로 owner(적)를 이동시킴
         // owner.scene은 현재 씬(BattleScene)에 접근하기 위함입니다.
-        owner.scene.physics.moveToObject(owner, target, owner.speed);
+        owner.scene.physics.moveToObject(owner, target, owner.stats.speed);
         return NodeStatus.SUCCESS;
     }
 }

--- a/src/data/units.js
+++ b/src/data/units.js
@@ -1,9 +1,16 @@
 // 유닛들의 기본 정보를 정의하는 파일입니다.
 export const UNITS = {
     WARRIOR: {
-        key: 'player', // 사용할 스프라이트 키 (현재 전사 이미지)
-        image: 'assets/images/unit/warrior.png', // 사용할 이미지 경로
-        name: '전사', // 유닛 이름
-        speed: 200 // 유닛의 이동 속도
+        // 사용할 스프라이트 키와 이미지 경로
+        key: 'unit_warrior',
+        name: '전사',
+        image: 'assets/images/unit/warrior.png',
+
+        // --- 기본 스탯 ---
+        hp: 100,
+        attack: 10,       // 물리 공격력
+        defense: 5,       // 물리 방어력
+        attackSpeed: 1000, // 1초에 한 번 공격
+        speed: 200        // 이동 속도
     }
 };

--- a/src/engine/CombatEngine.js
+++ b/src/engine/CombatEngine.js
@@ -1,0 +1,17 @@
+// 전투와 관련된 모든 계산을 담당하는 엔진입니다.
+export class CombatEngine {
+    /**
+     * 기본 데미지를 계산합니다.
+     * @param {object} attacker - 공격하는 유닛의 스탯
+     * @param {object} defender - 방어하는 유닛의 스탯
+     * @returns {number} 최종 데미지
+     */
+    static calculateDamage(attacker, defender) {
+        // 데미지 공식: 공격력 - 방어력
+        const damage = attacker.attack - defender.defense;
+
+        // 최소 데미지는 1로 보정
+        return Math.max(1, damage);
+    }
+}
+

--- a/src/game/Unit.js
+++ b/src/game/Unit.js
@@ -1,0 +1,58 @@
+import { Physics } from 'phaser';
+
+export class Unit extends Physics.Arcade.Sprite {
+    constructor(scene, x, y, unitData) {
+        // 부모 클래스(Sprite) 생성자 호출
+        super(scene, x, y, unitData.key);
+
+        // 1. 씬에 물리 객체로 추가
+        scene.add.existing(this);
+        scene.physics.add.existing(this);
+
+        // 2. 유닛 데이터와 스탯 설정
+        this.stats = { ...unitData }; // 원본 데이터를 복사하여 사용
+        this.lastAttackTime = 0; // 마지막 공격 시간
+
+        // 3. 체력바 생성 (VFX + 바인딩)
+        this.healthBar = scene.add.graphics();
+        this.updateHealthBar(); // 체력바 초기화
+
+        // 4. 레이어 설정
+        this.setDepth(1);
+        this.healthBar.setDepth(2);
+    }
+
+    // 체력이 변할 때마다 체력바를 다시 그리는 함수
+    updateHealthBar() {
+        this.healthBar.clear();
+        // 체력바 배경
+        this.healthBar.fillStyle(0x000000, 0.5);
+        this.healthBar.fillRect(-25, -40, 50, 8);
+        // 실제 체력
+        this.healthBar.fillStyle(0x00ff00, 1);
+        this.healthBar.fillRect(-25, -40, 50 * (this.stats.hp / 100), 8);
+    }
+
+    // 데미지를 받는 함수
+    takeDamage(damage) {
+        this.stats.hp -= damage;
+        if (this.stats.hp < 0) this.stats.hp = 0;
+
+        console.log(`${this.stats.name}이(가) ${damage}의 데미지를 입었습니다. 남은 체력: ${this.stats.hp}`);
+        this.updateHealthBar();
+
+        // 5. 피격 시 붉은색 점멸 효과 (VFX)
+        this.setTint(0xff0000);
+        this.scene.time.delayedCall(150, () => {
+            this.clearTint();
+        });
+    }
+
+    // preUpdate는 씬의 update가 실행되기 전에 매 프레임 자동으로 실행됩니다.
+    preUpdate(time, delta) {
+        super.preUpdate(time, delta);
+        // 체력바가 유닛을 따라다니도록 위치를 계속 업데이트합니다 (바인딩)
+        this.healthBar.setPosition(this.x, this.y);
+    }
+}
+

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -3,7 +3,7 @@ import { Game as MainGame } from './scenes/Game.js';
 import { GameOver } from './scenes/GameOver.js';
 import { MainMenu } from './scenes/MainMenu.js';
 import { Preloader } from './scenes/Preloader.js';
-import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import Phaser from 'phaser';
 
 const { AUTO, Game } = Phaser;
 

--- a/src/game/scenes/BattleScene.js
+++ b/src/game/scenes/BattleScene.js
@@ -1,5 +1,7 @@
-import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { Scene } from 'phaser';
 import { UNITS } from '../../data/units.js';
+import { CombatEngine } from '../../engine/CombatEngine.js';
+import { Unit } from '../Unit.js';
 import { MeleeAI } from '../../ai/meleeAI.js';
 
 export class BattleScene extends Scene {
@@ -7,66 +9,72 @@ export class BattleScene extends Scene {
         super('BattleScene');
         this.player = null;
         this.enemy = null;
-        this.enemyAI = null;
         this.cursors = null;
     }
 
     create() {
-        // 1. 배경 및 유닛 생성 (이전과 동일)
         this.add.image(512, 384, 'battle-background');
-        this.player = this.physics.add.sprite(200, 384, UNITS.WARRIOR.key);
-        this.enemy = this.physics.add.sprite(824, 384, UNITS.WARRIOR.key);
+
+        // Unit 클래스를 사용하여 플레이어와 적을 생성합니다.
+        this.player = new Unit(this, 200, 384, UNITS.WARRIOR);
+        this.enemy = new Unit(this, 824, 384, UNITS.WARRIOR);
         this.enemy.setFlipX(true);
-        this.enemy.speed = UNITS.WARRIOR.speed;
-        this.enemyAI = new MeleeAI(this.enemy, this.player);
+
+        // AI 설정
+        this.enemy.ai = new MeleeAI(this.enemy, this.player);
+
+        // 충돌 설정: 플레이어와 적이 부딪히면 handleCollision 함수를 호출
+        this.physics.add.collider(this.player, this.enemy, this.handleCollision, null, this);
+
         this.cursors = this.input.keyboard.createCursorKeys();
 
-        // === 카메라 엔진 기능 추가 시작 ===
-
-        // 2. 카메라 경계 설정
-        // 게임 월드의 전체 크기를 1600x1200으로 설정합니다.
-        // 이제 카메라는 이 경계 안에서만 움직일 수 있습니다.
+        // 카메라 설정 (기존과 동일)
         this.cameras.main.setBounds(0, 0, 1600, 1200);
-
-        // 3. 카메라 드래그 기능 구현
-        this.input.on('pointermove', (pointer) => {
-            if (!pointer.isDown) return;
-
-            const cam = this.cameras.main;
-            cam.scrollX -= (pointer.x - pointer.prevPosition.x) / cam.zoom;
-            cam.scrollY -= (pointer.y - pointer.prevPosition.y) / cam.zoom;
-        });
-
-        // 4. 카메라 줌 기능 구현 (마우스 휠)
-        this.input.on('wheel', (pointer, gameObjects, deltaX, deltaY) => {
-            const cam = this.cameras.main;
-            if (deltaY > 0) {
-                // 휠을 아래로 내리면 축소 (zoom out)
-                cam.zoom = Math.max(0.5, cam.zoom - 0.1);
-            } else {
-                // 휠을 위로 올리면 확대 (zoom in)
-                cam.zoom = Math.min(1.5, cam.zoom + 0.1);
+        this.input.on('pointermove', (p) => {
+            if (p.isDown) {
+                this.cameras.main.scrollX -= (p.x - p.prevPosition.x) / this.cameras.main.zoom;
+                this.cameras.main.scrollY -= (p.y - p.prevPosition.y) / this.cameras.main.zoom;
             }
         });
-
-        // === 카메라 엔진 기능 추가 끝 ===
-
+        this.input.on('wheel', (p, go, dx, dy) => {
+            const cam = this.cameras.main;
+            if (dy > 0) cam.zoom = Math.max(0.5, cam.zoom - 0.1);
+            else cam.zoom = Math.min(1.5, cam.zoom + 0.1);
+        });
         this.input.keyboard.on('keydown-M', () => {
             this.scene.start('WorldMap');
         });
     }
 
+    // 유닛들이 충돌했을 때 실행될 함수
+    handleCollision(unit1, unit2) {
+        const now = this.time.now;
+
+        if (now > unit1.lastAttackTime + unit1.stats.attackSpeed) {
+            const damage = CombatEngine.calculateDamage(unit1.stats, unit2.stats);
+            unit2.takeDamage(damage);
+            unit1.lastAttackTime = now;
+        }
+
+        if (now > unit2.lastAttackTime + unit2.stats.attackSpeed) {
+            const damage = CombatEngine.calculateDamage(unit2.stats, unit1.stats);
+            unit1.takeDamage(damage);
+            unit2.lastAttackTime = now;
+        }
+    }
+
     update(time, delta) {
-        // 플레이어 및 AI 업데이트 로직 (이전과 동일)
-        const speed = UNITS.WARRIOR.speed;
+        // 플레이어 움직임
+        const speed = this.player.stats.speed;
         this.player.setVelocity(0);
         if (this.cursors.left.isDown) this.player.setVelocityX(-speed);
         else if (this.cursors.right.isDown) this.player.setVelocityX(speed);
         if (this.cursors.up.isDown) this.player.setVelocityY(-speed);
         else if (this.cursors.down.isDown) this.player.setVelocityY(speed);
 
-        if (this.enemyAI) {
-            this.enemyAI.update();
+        // 적 AI 업데이트
+        if (this.enemy && this.enemy.ai) {
+            this.enemy.ai.update();
         }
     }
 }

--- a/src/game/scenes/Boot.js
+++ b/src/game/scenes/Boot.js
@@ -1,5 +1,4 @@
-// Load Phaser directly from a CDN so the game can run without a bundler.
-import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { Scene } from 'phaser';
 
 export class Boot extends Scene
 {

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -1,5 +1,4 @@
-// Import Phaser's Scene from a CDN so this module works standalone.
-import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { Scene } from 'phaser';
 
 export class Game extends Scene
 {

--- a/src/game/scenes/GameOver.js
+++ b/src/game/scenes/GameOver.js
@@ -1,5 +1,4 @@
-// Pull Scene from Phaser via CDN to keep the module self-contained.
-import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { Scene } from 'phaser';
 
 export class GameOver extends Scene
 {

--- a/src/game/scenes/MainMenu.js
+++ b/src/game/scenes/MainMenu.js
@@ -1,5 +1,4 @@
-// Use Phaser from a CDN so the project can run in the browser without bundling.
-import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { Scene } from 'phaser';
 
 export class MainMenu extends Scene
 {

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -1,5 +1,4 @@
-// Use the CDN version of Phaser to avoid module resolution issues.
-import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { Scene } from 'phaser';
 
 export class Preloader extends Scene
 {
@@ -38,7 +37,7 @@ export class Preloader extends Scene
         // 월드맵과 전투씬 배경, 플레이어 이미지를 불러옵니다.
         this.load.image('world-map-background', 'images/territory/cursed-forest.png');
         this.load.image('battle-background', 'images/battle/battle-stage-arena.png');
-        this.load.image('player', 'images/unit/warrior.png'); // 'player'라는 키로 전사 이미지를 불러옵니다.
+        this.load.image('unit_warrior', 'images/unit/warrior.png');
     }
 
     create ()

--- a/src/game/scenes/WorldMap.js
+++ b/src/game/scenes/WorldMap.js
@@ -1,5 +1,4 @@
-// Load Phaser's Scene from a CDN for better portability.
-import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { Scene } from 'phaser';
 
 export class WorldMap extends Scene
 {


### PR DESCRIPTION
## Summary
- centralize unit stats with HP, attack, defense, attack speed, and movement speed
- add CombatEngine to compute damage and Unit class to manage sprites and health bars
- rework BattleScene to use new Unit system and integrate basic AI movement

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898cb7c9ff4832798c0d3a6f8ef94e2