### PR TITLE
feat: add nameplate system for units

### DIFF
--- a/src/game/Nameplate.js
+++ b/src/game/Nameplate.js
@@ -1,0 +1,49 @@
+import { GameObjects, Scene } from 'phaser';
+
+// 유닛의 이름표를 관리하는 클래스
+export class Nameplate {
+    /**
+     * @param {Scene} scene - 현재 씬
+     * @param {import('./Unit.js').Unit} owner - 이 이름표의 주인인 유닛
+     * @param {string} text - 표시할 이름
+     */
+    constructor(scene, owner, text) {
+        this.scene = scene;
+        this.owner = owner;
+        this.text = text;
+
+        // 1. 고해상도 텍스트 생성 (화면에는 아직 보이지 않음)
+        // 폰트 크기를 2배(32px)로 설정하여 선명도를 높입니다.
+        const tempText = scene.add.text(0, 0, this.text, {
+            fontFamily: 'Arial Black',
+            fontSize: '32px',
+            color: '#ffffff',
+            stroke: '#000000',
+            strokeThickness: 6
+        }).setOrigin(0.5);
+
+        // 2. 오프스크린 렌더 텍스처 생성
+        // 텍스트 크기의 2배로 렌더 텍스처를 만듭니다.
+        this.renderTexture = scene.add.renderTexture(0, 0, tempText.width * 2, tempText.height * 2);
+        
+        // 3. 렌더 텍스처에 텍스트 그리기
+        this.renderTexture.draw(tempText, tempText.width, tempText.height);
+
+        // 4. 고해상도 텍스처를 절반으로 축소하여 선명하게 표시
+        this.renderTexture.setScale(0.5);
+        this.renderTexture.setDepth(3); // 체력바보다 위에 보이도록 설정
+
+        // 임시로 사용한 텍스트 객체는 파괴합니다.
+        tempText.destroy();
+    }
+
+    // 이름표의 위치를 주인(유닛)을 따라가도록 업데이트
+    update() {
+        this.renderTexture.setPosition(this.owner.x, this.owner.y - 55); // 유닛 머리 위로 위치 조정
+    }
+
+    // 유닛이 파괴될 때 이름표도 함께 파괴
+    destroy() {
+        this.renderTexture.destroy();
+    }
+}

--- a/src/game/Unit.js
+++ b/src/game/Unit.js
@@ -1,7 +1,9 @@
 import { Physics } from 'phaser';
+import { Nameplate } from './Nameplate.js'; // Nameplate 클래스 불러오기
 
 export class Unit extends Physics.Arcade.Sprite {
-    constructor(scene, x, y, unitData) {
+    // constructor의 인자로 name을 추가합니다.
+    constructor(scene, x, y, unitData, name) {
         // 부모 클래스(Sprite) 생성자 호출
         super(scene, x, y, unitData.key);
 
@@ -12,6 +14,9 @@ export class Unit extends Physics.Arcade.Sprite {
         // 2. 유닛 데이터와 스탯 설정
         this.stats = { ...unitData }; // 원본 데이터를 복사하여 사용
         this.lastAttackTime = 0; // 마지막 공격 시간
+
+        // --- 이름표 생성 코드 추가 ---
+        this.nameplate = new Nameplate(scene, this, name);
 
         // 3. 체력바 생성 (VFX + 바인딩)
         this.healthBar = scene.add.graphics();
@@ -38,7 +43,7 @@ export class Unit extends Physics.Arcade.Sprite {
         this.stats.hp -= damage;
         if (this.stats.hp < 0) this.stats.hp = 0;
 
-        console.log(`${this.stats.name}이(가) ${damage}의 데미지를 입었습니다. 남은 체력: ${this.stats.hp}`);
+        console.log(`${this.nameplate.text}이(가) ${damage}의 데미지를 입었습니다. 남은 체력: ${this.stats.hp}`);
         this.updateHealthBar();
 
         // 5. 피격 시 붉은색 점멸 효과 (VFX)
@@ -53,6 +58,18 @@ export class Unit extends Physics.Arcade.Sprite {
         super.preUpdate(time, delta);
         // 체력바가 유닛을 따라다니도록 위치를 계속 업데이트합니다 (바인딩)
         this.healthBar.setPosition(this.x, this.y);
+
+        // --- 이름표 위치 업데이트 코드 추가 ---
+        if (this.nameplate) {
+            this.nameplate.update();
+        }
+    }
+
+    // --- 유닛 파괴 시 관련 객체 모두 제거하는 함수 추가 ---
+    destroy(fromScene) {
+        if (this.nameplate) this.nameplate.destroy();
+        this.healthBar.destroy();
+        super.destroy(fromScene);
     }
 }
 

--- a/src/game/scenes/BattleScene.js
+++ b/src/game/scenes/BattleScene.js
@@ -16,8 +16,9 @@ export class BattleScene extends Scene {
         this.add.image(512, 384, 'battle-background');
 
         // Unit 클래스를 사용하여 플레이어와 적을 생성합니다.
-        this.player = new Unit(this, 200, 384, UNITS.WARRIOR);
-        this.enemy = new Unit(this, 824, 384, UNITS.WARRIOR);
+        // 각 유닛에게 이름을 부여하여 Nameplate에 표시합니다.
+        this.player = new Unit(this, 200, 384, UNITS.WARRIOR, '지휘관');
+        this.enemy = new Unit(this, 824, 384, UNITS.WARRIOR, '적 지휘관');
         this.enemy.setFlipX(true);
 
         // AI 설정


### PR DESCRIPTION
## Summary
- display crisp nameplates above units using high-resolution render textures
- hook nameplate lifecycle into Unit and BattleScene

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build-nolog`


------
https://chatgpt.com/codex/tasks/task_e_6898cd45f09883279f45f5a17fd86d95