### PR TITLE
fix: resolve phaser import via import map

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This template has been updated for:
 
 After cloning the repo, run `npm install` from your project directory. Then, you can start the local development server by running `npm run dev`.
 
+If you just want to experiment without starting the dev server, you can open `index.html` directly in a browser. An import map is included so the `phaser` module resolves from `node_modules` when loaded this way.
+
 The local development server runs on `http://localhost:8080` by default. Please see the Vite documentation if you wish to change this, or add SSL support.
 
 Once the server is running you can edit any of the files in the `src` folder. Vite will automatically recompile your code and then reload the browser.

--- a/index.html
+++ b/index.html
@@ -12,6 +12,13 @@
     <div id="app">
         <div id="game-container"></div>
     </div>
+    <script type="importmap">
+    {
+        "imports": {
+            "phaser": "./node_modules/phaser/dist/phaser.esm.js"
+        }
+    }
+    </script>
     <script type="module" src="src/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- map `phaser` specifier to local ESM bundle using an import map
- document loading index.html directly with the new import map

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898cfce22508327815f374988555e74