### PR TITLE
fix: load phaser from cdn

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <script type="importmap">
     {
         "imports": {
-            "phaser": "./node_modules/phaser/dist/phaser.esm.js"
+            "phaser": "https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js"
         }
     }
     </script>


### PR DESCRIPTION
## Summary
- avoid 404 by pulling Phaser from jsDelivr CDN

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6898d225d73483279cd254ddd1351e08