### PR TITLE
fix phaser import

### DIFF
--- a/src/ai/meleeAI.js
+++ b/src/ai/meleeAI.js
@@ -1,4 +1,4 @@
-import Phaser from 'phaser';
+import * as Phaser from 'phaser';
 
 // 행동 트리의 기본 노드 상태
 const NodeStatus = {

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -3,7 +3,7 @@ import { Game as MainGame } from './scenes/Game.js';
 import { GameOver } from './scenes/GameOver.js';
 import { MainMenu } from './scenes/MainMenu.js';
 import { Preloader } from './scenes/Preloader.js';
-import Phaser from 'phaser';
+import * as Phaser from 'phaser';
 
 const { AUTO, Game } = Phaser;
 


### PR DESCRIPTION
## Summary
- fix Phaser imports to use namespace syntax

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a0c9d866883279a08132d859ba147