### PR TITLE
feat: add turn-based grid movement

### DIFF
--- a/src/ai/meleeAI.js
+++ b/src/ai/meleeAI.js
@@ -1,99 +1,33 @@
-import * as Phaser from 'phaser';
-
-// 행동 트리의 기본 노드 상태
-const NodeStatus = {
-    SUCCESS: 'SUCCESS',
-    FAILURE: 'FAILURE',
-    RUNNING: 'RUNNING',
-};
-
-// 기본 노드 클래스 (모든 노드들의 부모)
-class BehaviorNode {
-    execute(owner, target) {
-        throw new Error("실행 메소드가 구현되지 않았습니다.");
-    }
-}
-
-// Sequence 노드: 모든 자식이 성공해야 성공
-class Sequence extends BehaviorNode {
-    constructor(nodes) {
-        super();
-        this.nodes = nodes;
-    }
-
-    execute(owner, target) {
-        for (const node of this.nodes) {
-            if (node.execute(owner, target) === NodeStatus.FAILURE) {
-                return NodeStatus.FAILURE;
-            }
-        }
-        return NodeStatus.SUCCESS;
-    }
-}
-
-// --- AI를 위한 실제 노드들 ---
-
-// 조건 노드: 플레이어가 추격 범위 안에 있는지 확인
-class IsPlayerInChaseRange extends BehaviorNode {
-    constructor(range) {
-        super();
-        this.range = range;
-    }
-
-    execute(owner, target) {
-        // owner(적)와 target(플레이어) 사이의 거리를 계산
-        const distance = Phaser.Math.Distance.Between(owner.x, owner.y, target.x, target.y);
-        
-        if (distance <= this.range) {
-            console.log('플레이어 발견! 추격 시작.');
-            return NodeStatus.SUCCESS; // 범위 안이면 성공
-        }
-        return NodeStatus.FAILURE; // 범위 밖이면 실패
-    }
-}
-
-// 행동 노드: 플레이어를 향해 이동
-class MoveToPlayer extends BehaviorNode {
-    execute(owner, target) {
-        // 물리 엔진을 사용하여 target(플레이어) 방향으로 owner(적)를 이동시킴
-        // owner.scene은 현재 씬(BattleScene)에 접근하기 위함입니다.
-        owner.scene.physics.moveToObject(owner, target, owner.stats.speed);
-        return NodeStatus.SUCCESS;
-    }
-}
-
-// 행동 노드: 정지
-class StopMovement extends BehaviorNode {
-    execute(owner) {
-        owner.setVelocity(0, 0);
-        return NodeStatus.SUCCESS;
-    }
-}
-
-
-// --- 실제 MeleeAI 클래스 ---
+// AI가 행동을 결정하는 클래스
 export class MeleeAI {
-    constructor(owner, target) {
-        this.owner = owner;   // 이 AI를 사용하는 적 캐릭터
-        this.target = target; // 공격 대상 (플레이어)
-        
-        // AI의 행동 트리 구조를 정의합니다.
-        this.root = new Sequence([
-            new IsPlayerInChaseRange(300), // 300픽셀 범위 안에 들어오면
-            new MoveToPlayer()             // 플레이어를 향해 이동한다
-        ]);
-
-        // 추격 범위 밖에 있을 때를 위한 대체 행동
-        this.idleBehavior = new StopMovement();
+    constructor(owner) {
+        this.owner = owner; // 이 AI의 주인
     }
 
-    update() {
-        // 매 프레임마다 행동 트리의 최상단(root)부터 실행
-        const result = this.root.execute(this.owner, this.target);
+    // 어떤 행동을 할지 결정해서 반환
+    decideAction(target) {
+        const ownerPos = this.owner.gridPosition;
+        const targetPos = target.gridPosition;
 
-        // 만약 행동 트리가 실패했다면 (플레이어가 범위 밖에 있다면)
-        if (result === NodeStatus.FAILURE) {
-            this.idleBehavior.execute(this.owner); // 정지 행동을 실행
+        let nextX = ownerPos.x;
+        let nextY = ownerPos.y;
+
+        // 타겟과의 거리 차이를 기반으로 다음 위치 결정 (간단한 추격 로직)
+        if (targetPos.x < ownerPos.x) nextX--;
+        else if (targetPos.x > ownerPos.x) nextX++;
+        else if (targetPos.y < ownerPos.y) nextY--;
+        else if (targetPos.y > ownerPos.y) nextY++;
+        
+        // 이동할 위치가 현재 위치와 같지 않다면, 이동 행동을 반환
+        if (nextX !== ownerPos.x || nextY !== ownerPos.y) {
+            return {
+                type: 'move',
+                unit: this.owner,
+                targetPosition: { x: nextX, y: nextY }
+            };
         }
+
+        return null; // 움직일 필요가 없으면 아무 행동도 안함
     }
 }
+

--- a/src/engine/TurnManager.js
+++ b/src/engine/TurnManager.js
@@ -1,0 +1,45 @@
+export const TurnState = {
+    PLAYER_INPUT: 'PLAYER_INPUT', // 플레이어의 입력을 기다리는 상태
+    PROCESSING: 'PROCESSING',     // 유닛들의 행동이 진행 중인 상태
+};
+
+export class TurnManager {
+    constructor(scene) {
+        this.scene = scene;
+        this.state = TurnState.PLAYER_INPUT;
+        this.actionQueue = []; // 실행할 행동들을 담는 큐
+    }
+
+    // 플레이어가 행동을 결정했을 때 호출
+    playerAction(action) {
+        if (this.state === TurnState.PLAYER_INPUT) {
+            this.actionQueue.push(action);
+            this.state = TurnState.PROCESSING; // 처리 상태로 변경
+            console.log("플레이어 행동 접수. 처리 시작...");
+            this.processQueue();
+        }
+    }
+
+    // 큐에 쌓인 행동들을 순차적으로 처리
+    async processQueue() {
+        // 현재 씬의 모든 유닛이 행동을 결정하게 함 (AI)
+        this.scene.enemies.forEach(enemy => {
+            if (enemy.ai) {
+                const enemyAction = enemy.ai.decideAction(this.scene.player);
+                if (enemyAction) {
+                    this.actionQueue.push(enemyAction);
+                }
+            }
+        });
+
+        // 큐에 있는 모든 행동이 끝날 때까지 기다림
+        while (this.actionQueue.length > 0) {
+            const action = this.actionQueue.shift(); // 큐에서 행동 하나를 꺼냄
+            await action.unit.executeAction(action); // 행동이 끝날 때까지 대기
+        }
+
+        console.log("모든 행동 처리 완료. 플레이어 입력 대기.");
+        this.state = TurnState.PLAYER_INPUT; // 다시 플레이어 입력 대기 상태로
+    }
+}
+

--- a/src/game/scenes/BattleScene.js
+++ b/src/game/scenes/BattleScene.js
@@ -1,82 +1,110 @@
 import { Scene } from 'phaser';
 import { UNITS } from '../../data/units.js';
-import { CombatEngine } from '../../engine/CombatEngine.js';
-import { Unit } from '../Unit.js';
 import { MeleeAI } from '../../ai/meleeAI.js';
+import { Unit } from '../Unit.js';
+import { TurnManager, TurnState } from '../../engine/TurnManager.js';
+
+// 그리드 계산을 도와줄 헬퍼 클래스
+class Grid {
+    constructor(scene, width, height, tileSize) {
+        this.scene = scene;
+        this.width = width;
+        this.height = height;
+        this.tileSize = tileSize;
+        // 그리드가 화면 중앙에 오도록 오프셋 계산
+        this.offsetX = (scene.scale.width - (width * tileSize)) / 2;
+        this.offsetY = (scene.scale.height - (height * tileSize)) / 2;
+    }
+
+    // 그리드 좌표를 실제 화면 좌표로 변환
+    getWorldPosition(x, y) {
+        return {
+            x: this.offsetX + x * this.tileSize + this.tileSize / 2,
+            y: this.offsetY + y * this.tileSize + this.tileSize / 2
+        };
+    }
+
+    // 그리드를 시각적으로 그리는 함수 (개발용)
+    draw() {
+        const graphics = this.scene.add.graphics();
+        graphics.lineStyle(1, 0xffffff, 0.2);
+        for (let i = 0; i <= this.width; i++) {
+            const x = this.offsetX + i * this.tileSize;
+            graphics.lineBetween(x, this.offsetY, x, this.offsetY + this.height * this.tileSize);
+        }
+        for (let j = 0; j <= this.height; j++) {
+            const y = this.offsetY + j * this.tileSize;
+            graphics.lineBetween(this.offsetX, y, this.offsetX + this.width * this.tileSize, y);
+        }
+    }
+}
 
 export class BattleScene extends Scene {
     constructor() {
         super('BattleScene');
+        this.grid = null;
+        this.turnManager = null;
         this.player = null;
-        this.enemy = null;
-        this.cursors = null;
+        this.enemies = [];
     }
 
     create() {
         this.add.image(512, 384, 'battle-background');
 
-        // Unit 클래스를 사용하여 플레이어와 적을 생성합니다.
-        // 각 유닛에게 이름을 부여하여 Nameplate에 표시합니다.
-        this.player = new Unit(this, 200, 384, UNITS.WARRIOR, '지휘관');
-        this.enemy = new Unit(this, 824, 384, UNITS.WARRIOR, '적 지휘관');
-        this.enemy.setFlipX(true);
+        // 1. 그리드 생성
+        this.grid = new Grid(this, 16, 9, 64); // 16x9, 타일 크기 64
+        this.grid.draw(); // 개발 편의를 위해 그리드를 화면에 표시
 
-        // AI 설정
-        this.enemy.ai = new MeleeAI(this.enemy, this.player);
+        // 2. 턴 매니저 생성
+        this.turnManager = new TurnManager(this);
 
-        // 충돌 설정: 플레이어와 적이 부딪히면 handleCollision 함수를 호출
-        this.physics.add.collider(this.player, this.enemy, this.handleCollision, null, this);
+        // 3. 그리드 위에 유닛 배치
+        this.player = new Unit(this, 3, 4, UNITS.WARRIOR, '지휘관');
+        const enemy = new Unit(this, 12, 4, UNITS.WARRIOR, '적 지휘관');
+        enemy.setFlipX(true);
+        this.enemies.push(enemy);
 
-        this.cursors = this.input.keyboard.createCursorKeys();
+        // 4. 적 AI 설정
+        enemy.ai = new MeleeAI(enemy);
 
-        // 카메라 설정 (기존과 동일)
+        // 5. 키보드 입력 설정
+        this.input.keyboard.on('keydown', event => this.handleKeyPress(event));
+        
+        // 이전 카메라/월드맵 이동 코드는 유지
         this.cameras.main.setBounds(0, 0, 1600, 1200);
-        this.input.on('pointermove', (p) => {
-            if (p.isDown) {
-                this.cameras.main.scrollX -= (p.x - p.prevPosition.x) / this.cameras.main.zoom;
-                this.cameras.main.scrollY -= (p.y - p.prevPosition.y) / this.cameras.main.zoom;
-            }
-        });
-        this.input.on('wheel', (p, go, dx, dy) => {
-            const cam = this.cameras.main;
-            if (dy > 0) cam.zoom = Math.max(0.5, cam.zoom - 0.1);
-            else cam.zoom = Math.min(1.5, cam.zoom + 0.1);
-        });
-        this.input.keyboard.on('keydown-M', () => {
-            this.scene.start('WorldMap');
-        });
+        this.input.on('pointermove', (p) => { if (p.isDown) { this.cameras.main.scrollX -= (p.x - p.prevPosition.x) / this.cameras.main.zoom; this.cameras.main.scrollY -= (p.y - p.prevPosition.y) / this.cameras.main.zoom; }});
+        this.input.on('wheel', (p, go, dx, dy) => { const cam = this.cameras.main; if (dy > 0) cam.zoom = Math.max(0.5, cam.zoom - 0.1); else cam.zoom = Math.min(1.5, cam.zoom + 0.1); });
+        this.input.keyboard.on('keydown-M', () => { this.scene.start('WorldMap'); });
     }
 
-    // 유닛들이 충돌했을 때 실행될 함수
-    handleCollision(unit1, unit2) {
-        const now = this.time.now;
+    // 키 입력을 처리하는 함수
+    handleKeyPress(event) {
+        // 플레이어 턴일 때만 입력을 받음
+        if (this.turnManager.state !== TurnState.PLAYER_INPUT) return;
 
-        if (now > unit1.lastAttackTime + unit1.stats.attackSpeed) {
-            const damage = CombatEngine.calculateDamage(unit1.stats, unit2.stats);
-            unit2.takeDamage(damage);
-            unit1.lastAttackTime = now;
+        let targetX = this.player.gridPosition.x;
+        let targetY = this.player.gridPosition.y;
+
+        switch (event.code) {
+            case 'ArrowUp': targetY--; break;
+            case 'ArrowDown': targetY++; break;
+            case 'ArrowLeft': targetX--; break;
+            case 'ArrowRight': targetX++; break;
+            default: return; // 화살표 키가 아니면 무시
         }
-
-        if (now > unit2.lastAttackTime + unit2.stats.attackSpeed) {
-            const damage = CombatEngine.calculateDamage(unit2.stats, unit1.stats);
-            unit1.takeDamage(damage);
-            unit2.lastAttackTime = now;
-        }
-    }
-
-    update(time, delta) {
-        // 플레이어 움직임
-        const speed = this.player.stats.speed;
-        this.player.setVelocity(0);
-        if (this.cursors.left.isDown) this.player.setVelocityX(-speed);
-        else if (this.cursors.right.isDown) this.player.setVelocityX(speed);
-        if (this.cursors.up.isDown) this.player.setVelocityY(-speed);
-        else if (this.cursors.down.isDown) this.player.setVelocityY(speed);
-
-        // 적 AI 업데이트
-        if (this.enemy && this.enemy.ai) {
-            this.enemy.ai.update();
+        
+        // 이동할 위치가 유효한지 확인 (그리드 범위 안)
+        if (targetX >= 0 && targetX < this.grid.width && targetY >= 0 && targetY < this.grid.height) {
+            // 턴 매니저에게 플레이어의 행동을 전달
+            this.turnManager.playerAction({
+                type: 'move',
+                unit: this.player,
+                targetPosition: { x: targetX, y: targetY }
+            });
         }
     }
+    
+    // BattleScene의 update는 이제 아무것도 하지 않습니다. 모든 로직은 TurnManager가 관리합니다.
+    update(time, delta) {}
 }
 


### PR DESCRIPTION
## Summary
- introduce TurnManager to queue and resolve unit actions
- convert melee AI to suggest moves on its turn
- give Unit grid-aware movement and update BattleScene to run a grid-based turn cycle

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689b3db973188327baefbb3f4d3c515d