### PR TITLE
Expand tile size and restore camera controls

### DIFF
--- a/src/engine/SizingManager.js
+++ b/src/engine/SizingManager.js
@@ -3,7 +3,7 @@ export const SizingManager = {
     // 그리드 설정
     GRID_WIDTH: 16,      // 그리드의 가로 타일 수
     GRID_HEIGHT: 9,      // 그리드의 세로 타일 수
-    TILE_SIZE: 64,       // 각 타일의 한 변 크기 (픽셀)
+    TILE_SIZE: 512,       // 각 타일의 한 변 크기 (픽셀)
 
     // UI 및 기타 요소
     NAMEPLATE_FONT_SIZE: 32, // 이름표 폰트 크기 (고해상도 기준)

--- a/src/game/scenes/BattleScene.js
+++ b/src/game/scenes/BattleScene.js
@@ -34,6 +34,28 @@ export class BattleScene extends Scene {
         // 3. 입력 및 기타 설정
         this.input.keyboard.on('keydown', event => this.handleKeyPress(event));
         this.input.keyboard.on('keydown-M', () => { this.scene.start('WorldMap'); });
+
+        // --- 카메라 드래그 및 확대/축소 기능 추가 ---
+        const worldWidth = this.grid.width * this.grid.tileSize;
+        const worldHeight = this.grid.height * this.grid.tileSize;
+        this.cameras.main.setBounds(this.grid.offsetX, this.grid.offsetY, worldWidth, worldHeight);
+
+        this.input.on('pointermove', (pointer) => {
+            if (!pointer.isDown) {
+                return;
+            }
+
+            this.cameras.main.scrollX -= (pointer.x - pointer.prevPosition.x) / this.cameras.main.zoom;
+            this.cameras.main.scrollY -= (pointer.y - pointer.prevPosition.y) / this.cameras.main.zoom;
+        });
+
+        this.input.on('wheel', (pointer, gameObjects, deltaX, deltaY) => {
+            if (deltaY > 0) {
+                this.cameras.main.zoom *= 0.9;
+            } else if (deltaY < 0) {
+                this.cameras.main.zoom *= 1.1;
+            }
+        });
     }
 
     handleKeyPress(event) {


### PR DESCRIPTION
## Summary
- Increase tile size constant for grid tiles to 512 pixels
- Reintroduce camera dragging and add zoom support in BattleScene

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c7a9c366083278047a6c87bc0e589