### PR TITLE
feat: introduce MapManager and expand battle grid

### DIFF
--- a/src/engine/MapManager.js
+++ b/src/engine/MapManager.js
@@ -1,0 +1,36 @@
+import { SizingManager } from './SizingManager.js';
+
+// 맵 타일의 생성 및 무작위 배치를 담당하는 매니저
+export class MapManager {
+    constructor(scene) {
+        this.scene = scene;
+        this.grid = scene.grid;
+        this.mapTiles = [];
+    }
+
+    // 맵 타일 에셋을 불러오는 함수
+    static preload(scene) {
+        for (let i = 1; i <= 15; i++) {
+            scene.load.image(`mab-tile-${i}`, `assets/images/world-mab/mab-tile-${i}.png`);
+        }
+    }
+
+    // 맵을 생성하는 함수
+    createMap() {
+        const graphics = this.scene.add.graphics();
+        graphics.setDepth(-2); // 타일보다 뒤에 그려지도록 설정
+
+        for (let y = 0; y < this.grid.height; y++) {
+            for (let x = 0; x < this.grid.width; x++) {
+                const tileKey = `mab-tile-${Phaser.Math.Between(1, 15)}`;
+                const worldPos = this.grid.getWorldPosition(x, y);
+                const tile = this.scene.add.image(worldPos.x, worldPos.y, tileKey);
+
+                // 타일 크기를 그리드 셀에 맞게 조절합니다.
+                tile.setDisplaySize(SizingManager.TILE_SIZE, SizingManager.TILE_SIZE);
+                tile.setDepth(-1);
+                this.mapTiles.push(tile);
+            }
+        }
+    }
+}

--- a/src/engine/SizingManager.js
+++ b/src/engine/SizingManager.js
@@ -1,9 +1,9 @@
 // 게임의 모든 크기 및 비율 관련 상수를 정의하는 매니저
 export const SizingManager = {
     // 그리드 설정
-    GRID_WIDTH: 16,      // 그리드의 가로 타일 수
-    GRID_HEIGHT: 9,      // 그리드의 세로 타일 수
-    TILE_SIZE: 512,       // 각 타일의 한 변 크기 (픽셀)
+    GRID_WIDTH: 30,      // 그리드의 가로 타일 수
+    GRID_HEIGHT: 30,     // 그리드의 세로 타일 수
+    TILE_SIZE: 128,      // 각 타일의 한 변 크기 (픽셀)
 
     // UI 및 기타 요소
     NAMEPLATE_FONT_SIZE: 32, // 이름표 폰트 크기 (고해상도 기준)

--- a/src/game/scenes/BattleScene.js
+++ b/src/game/scenes/BattleScene.js
@@ -4,29 +4,35 @@ import { MeleeAI } from '../../ai/meleeAI.js';
 import { Unit } from '../Unit.js';
 import { TurnManager, TurnState } from '../../engine/TurnManager.js';
 import { GridManager } from '../../engine/GridManager.js'; // 그리드 매니저 불러오기
+import { MapManager } from '../../engine/MapManager.js'; // MapManager를 불러옵니다.
 
 export class BattleScene extends Scene {
     constructor() {
         super('BattleScene');
-        this.grid = null; // 이제 GridManager 인스턴스를 담습니다.
+        this.grid = null; 
+        this.mapManager = null; // mapManager 속성 추가
         this.turnManager = null;
         this.player = null;
         this.enemies = [];
     }
 
     create() {
-        this.add.image(512, 384, 'battle-background').setDepth(-1);
+        // this.add.image(512, 384, 'battle-background').setDepth(-1); // MapManager가 배경을 그리므로 주석 처리
 
         // 1. 매니저들 생성
         this.grid = new GridManager(this);
+        this.mapManager = new MapManager(this); // MapManager 인스턴스 생성
         this.turnManager = new TurnManager(this);
-        
+
+        // MapManager를 사용하여 맵 타일을 생성합니다.
+        this.mapManager.createMap();
+
         // 개발 편의를 위해 그리드를 화면에 표시
         this.grid.draw();
 
-        // 2. 그리드 위에 유닛 배치
-        this.player = new Unit(this, 3, 4, UNITS.WARRIOR, '지휘관');
-        const enemy = new Unit(this, 12, 4, UNITS.WARRIOR, '적 지휘관');
+        // 2. 그리드 위에 유닛 배치 (30x30에 맞게 위치 조정)
+        this.player = new Unit(this, 5, 15, UNITS.WARRIOR, '지휘관');
+        const enemy = new Unit(this, 24, 15, UNITS.WARRIOR, '적 지휘관');
         enemy.setFlipX(true);
         this.enemies.push(enemy);
         enemy.ai = new MeleeAI(enemy);
@@ -40,6 +46,10 @@ export class BattleScene extends Scene {
         const worldHeight = this.grid.height * this.grid.tileSize;
         this.cameras.main.setBounds(this.grid.offsetX, this.grid.offsetY, worldWidth, worldHeight);
 
+        // 카메라가 플레이어를 따라다니도록 설정
+        this.cameras.main.startFollow(this.player, true, 0.08, 0.08);
+        this.cameras.main.setZoom(1.5); // 초기 줌 레벨 설정
+
         this.input.on('pointermove', (pointer) => {
             if (!pointer.isDown) {
                 return;
@@ -51,9 +61,9 @@ export class BattleScene extends Scene {
 
         this.input.on('wheel', (pointer, gameObjects, deltaX, deltaY) => {
             if (deltaY > 0) {
-                this.cameras.main.zoom *= 0.9;
+                this.cameras.main.zoom = Math.max(0.5, this.cameras.main.zoom * 0.9);
             } else if (deltaY < 0) {
-                this.cameras.main.zoom *= 1.1;
+                this.cameras.main.zoom = Math.min(3, this.cameras.main.zoom * 1.1);
             }
         });
     }

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -1,4 +1,5 @@
 import { Scene } from 'phaser';
+import { MapManager } from '../../engine/MapManager.js'; // MapManager를 불러옵니다.
 
 export class Preloader extends Scene
 {
@@ -36,8 +37,11 @@ export class Preloader extends Scene
 
         // 월드맵과 전투씬 배경, 플레이어 이미지를 불러옵니다.
         this.load.image('world-map-background', 'images/territory/cursed-forest.png');
-        this.load.image('battle-background', 'images/battle/battle-stage-arena.png');
+        // this.load.image('battle-background', 'images/battle/battle-stage-arena.png'); // MapManager가 배경을 그리므로 주석 처리
         this.load.image('unit_warrior', 'images/unit/warrior.png');
+
+        // MapManager를 사용하여 맵 타일 에셋을 로드합니다.
+        MapManager.preload(this);
     }
 
     create ()


### PR DESCRIPTION
## Summary
- add MapManager to build random tile maps
- expand grid sizing to 30x30 tiles and adjust tile size
- load map tile assets during preload and generate map in battle scene

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c7ebc6cd48327ac3d484c922f9e69