### PR TITLE
fix: adjust Phaser import in MapManager

### DIFF
--- a/src/engine/MapManager.js
+++ b/src/engine/MapManager.js
@@ -1,4 +1,4 @@
-import Phaser from 'phaser';
+import * as Phaser from 'phaser';
 import { SizingManager } from './SizingManager.js';
 
 // 맵 타일의 생성 및 무작위 배치를 담당하는 매니저


### PR DESCRIPTION
## Summary
- import Phaser as a namespace instead of default in MapManager to match ESM exports

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d992878848327badb13c482d16a0b