### PR TITLE
Add floor tiles and player movement

### DIFF
--- a/src/engine/DungeonManager.js
+++ b/src/engine/DungeonManager.js
@@ -23,11 +23,12 @@ class Room {
 }
 
 export class DungeonManager {
-    constructor(scene, width, height, wallTileKey) {
+    constructor(scene, width, height, wallTileKey, floorTileKey) {
         this.scene = scene;
         this.width = width;
         this.height = height;
         this.wallTileKey = wallTileKey;
+        this.floorTileKey = floorTileKey;
         this.tiles = []; // 맵의 타일 데이터를 저장할 2D 배열
         this.rooms = [];
     }
@@ -169,10 +170,20 @@ export class DungeonManager {
     renderDungeon(tileSize) {
         for (let x = 0; x < this.width; x++) {
             for (let y = 0; y < this.height; y++) {
-                if (this.tiles[x][y] === 1) { // 벽일 경우
+                const tile = this.tiles[x][y];
+                if (tile === 1) {
                     this.scene.add.image(x * tileSize, y * tileSize, this.wallTileKey).setOrigin(0);
+                } else if (tile === 0) {
+                    this.scene.add.image(x * tileSize, y * tileSize, this.floorTileKey).setOrigin(0);
                 }
             }
         }
+    }
+
+    getTileAt(x, y) {
+        if (x >= 0 && x < this.width && y >= 0 && y < this.height) {
+            return this.tiles[x][y];
+        }
+        return 1; // 맵 밖은 벽으로 처리
     }
 }

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -35,8 +35,9 @@ export class Preloader extends Scene
 
         this.load.image('logo', 'logo.png');
 
-        // 월드맵 배경 대신 벽 타일을 로드합니다.
+        // 월드맵 타일을 로드합니다.
         this.load.image('wall-tile', 'images/world-mab/wall-tile-1.png');
+        this.load.image('floor-tile', 'images/world-mab/floor-tile-1.png');
 
         this.load.image('unit_warrior', 'images/unit/warrior.png');
 

--- a/src/game/scenes/WorldMap.js
+++ b/src/game/scenes/WorldMap.js
@@ -7,25 +7,43 @@ export class WorldMap extends Scene
     constructor ()
     {
         super('WorldMap');
-
         this.dungeonManager = null;
+        this.commander = null;
+        this.cursors = null;
+        this.tileSize = SizingManager.TILE_SIZE;
     }
 
     create ()
     {
-        const TILE_SIZE = SizingManager.TILE_SIZE; // 타일 크기
-        const DUNGEON_WIDTH = 50; // 던전의 가로 타일 수
-        const DUNGEON_HEIGHT = 50; // 던전의 세로 타일 수
+        const DUNGEON_WIDTH = 50;
+        const DUNGEON_HEIGHT = 50;
 
-        //  DungeonManager 인스턴스 생성
-        this.dungeonManager = new DungeonManager(this, DUNGEON_WIDTH, DUNGEON_HEIGHT, 'wall-tile');
+        this.dungeonManager = new DungeonManager(this, DUNGEON_WIDTH, DUNGEON_HEIGHT, 'wall-tile', 'floor-tile');
+        const dungeonTiles = this.dungeonManager.generateDungeon();
+        this.dungeonManager.renderDungeon(this.tileSize);
 
-        //  던전 생성 및 렌더링
-        this.dungeonManager.generateDungeon();
-        this.dungeonManager.renderDungeon(TILE_SIZE);
-        
-        //  안내 텍스트 추가
-        this.add.text(this.scale.width / 2, this.scale.height - 50, '던전이 생성되었습니다. B 키로 전투를 시작하세요.', {
+        let startX = -1, startY = -1;
+        for (let x = 1; x < DUNGEON_WIDTH - 1; x++) {
+            for (let y = 1; y < DUNGEON_HEIGHT - 1; y++) {
+                if (dungeonTiles[x] && dungeonTiles[x][y] === 0) {
+                    startX = x * this.tileSize + this.tileSize / 2;
+                    startY = y * this.tileSize + this.tileSize / 2;
+                    break;
+                }
+            }
+            if (startX !== -1) {
+                break;
+            }
+        }
+
+        if (startX !== -1 && startY !== -1) {
+            this.commander = this.add.sprite(startX, startY, 'unit_warrior').setOrigin(0.5);
+            this.cameras.main.startFollow(this.commander);
+        } else {
+            console.warn('시작 지점을 찾을 수 없습니다.');
+        }
+        const info = '던전이 생성되었습니다. 방향키로 이동하세요. B 키로 전투 시작.';
+        this.add.text(this.scale.width / 2, this.scale.height - 50, info, {
             fontFamily: 'Arial Black',
             fontSize: 32,
             color: '#ffffff',
@@ -34,8 +52,7 @@ export class WorldMap extends Scene
             align: 'center'
         }).setOrigin(0.5);
 
-        //  카메라 설정
-        this.cameras.main.setBounds(0, 0, DUNGEON_WIDTH * TILE_SIZE, DUNGEON_HEIGHT * TILE_SIZE);
+        this.cameras.main.setBounds(0, 0, DUNGEON_WIDTH * this.tileSize, DUNGEON_HEIGHT * this.tileSize);
         this.input.on('pointermove', (pointer) => {
             if (!pointer.isDown)
             {
@@ -45,8 +62,7 @@ export class WorldMap extends Scene
             this.cameras.main.scrollX -= (pointer.x - pointer.prevPosition.x) / this.cameras.main.zoom;
             this.cameras.main.scrollY -= (pointer.y - pointer.prevPosition.y) / this.cameras.main.zoom;
         });
-        
-        // 마우스 휠로 줌 기능 추가
+
         this.input.on('wheel', (pointer, gameObjects, deltaX, deltaY) => {
             if (deltaY > 0) {
                 this.cameras.main.zoom = Math.max(0.5, this.cameras.main.zoom * 0.9);
@@ -55,9 +71,39 @@ export class WorldMap extends Scene
             }
         });
 
-        //  'B' 키를 눌러 전투 씬으로 전환
+        this.cursors = this.input.keyboard.createCursorKeys();
+
         this.input.keyboard.on('keydown-B', () => {
             this.scene.start('BattleScene');
         });
     }
+
+    update(time, delta) {
+        if (!this.commander || !this.cursors) {
+            return;
+        }
+
+        const speed = this.tileSize * delta / 1000;
+        const prevX = this.commander.x;
+        const prevY = this.commander.y;
+
+        if (this.cursors.left.isDown) {
+            this.commander.x -= speed;
+        } else if (this.cursors.right.isDown) {
+            this.commander.x += speed;
+        } else if (this.cursors.up.isDown) {
+            this.commander.y -= speed;
+        } else if (this.cursors.down.isDown) {
+            this.commander.y += speed;
+        }
+
+        const tileX = Math.floor(this.commander.x / this.tileSize);
+        const tileY = Math.floor(this.commander.y / this.tileSize);
+
+        if (this.dungeonManager.getTileAt(tileX, tileY) === 1) {
+            this.commander.x = prevX;
+            this.commander.y = prevY;
+        }
+    }
 }
+


### PR DESCRIPTION
## Summary
- Render both wall and floor tiles for dungeon maps
- Load floor tile asset and spawn a movable commander
- Add basic collision checks against dungeon walls

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e15406aec832796555923d45b093d