### PR TITLE
feat: show player party on dungeon map

### DIFF
--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -40,6 +40,8 @@ export class Preloader extends Scene
         this.load.image('floor-tile', 'images/world-mab/floor-tile-1.png');
 
         this.load.image('unit_warrior', 'images/unit/warrior.png');
+        this.load.image('unit_gunner', 'images/unit/gunner.png');
+        this.load.image('unit_medic', 'images/unit/medic.png');
 
         // MapManager를 사용하여 맵 타일 에셋을 로드합니다.
         MapManager.preload(this);

--- a/src/game/scenes/WorldMap.js
+++ b/src/game/scenes/WorldMap.js
@@ -41,10 +41,22 @@ export class WorldMap extends Scene
         }
 
         if (startX !== -1 && startY !== -1) {
-            this.commander = this.physics.add.sprite(startX, startY, 'unit_warrior')
-                .setOrigin(0.5)
-                .setDisplaySize(80, 80);
-            // 전투 씬과 동일하게 부드러운 카메라 이동을 적용
+            // 파티를 하나의 컨테이너에 담아 단일 유닛처럼 이동하게 한다
+            const party = this.add.container(startX, startY);
+
+            // 전사(선봉), 거너, 메딕 순서로 배치
+            const gunner = this.add.sprite(-15, -8, 'unit_gunner')
+                .setDisplaySize(40, 40);
+            const medic = this.add.sprite(15, -8, 'unit_medic')
+                .setDisplaySize(40, 40);
+            const warrior = this.add.sprite(0, 8, 'unit_warrior')
+                .setDisplaySize(48, 48);
+
+            party.add([gunner, medic, warrior]);
+
+            this.commander = party;
+
+            // 부드러운 카메라 이동 및 확대 설정
             this.cameras.main.startFollow(this.commander, true, 0.08, 0.08);
             this.cameras.main.setZoom(1.5);
         } else {


### PR DESCRIPTION
## Summary
- render warrior, gunner and medic sprites as one party container on dungeon map
- preload gunner and medic assets for world map scene

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1fdcaaa6483279773cd879bf58875