### PR TITLE
Render dungeon tiles using whole images

### DIFF
--- a/src/engine/DungeonManager.js
+++ b/src/engine/DungeonManager.js
@@ -234,14 +234,21 @@ export class DungeonManager {
     }
     
     // 생성된 던전을 화면에 그리는 함수
-    renderDungeon(tileSize) {
+    renderDungeon() {
+        const wallTexture = this.scene.textures.get(this.wallTileKey).getSourceImage();
+        const tileWidth = wallTexture.width;
+        const tileHeight = wallTexture.height;
+
         for (let x = 0; x < this.width; x++) {
             for (let y = 0; y < this.height; y++) {
                 const tile = this.tiles[x][y];
+                const posX = x * tileWidth;
+                const posY = y * tileHeight;
+
                 if (tile === 1) {
-                    this.scene.add.image(x * tileSize, y * tileSize, this.wallTileKey).setOrigin(0);
+                    this.scene.add.image(posX, posY, this.wallTileKey).setOrigin(0);
                 } else if (tile === 0) {
-                    this.scene.add.image(x * tileSize, y * tileSize, this.floorTileKey).setOrigin(0);
+                    this.scene.add.image(posX, posY, this.floorTileKey).setOrigin(0);
                 }
             }
         }

--- a/src/game/scenes/WorldMap.js
+++ b/src/game/scenes/WorldMap.js
@@ -1,7 +1,6 @@
 import * as Phaser from 'phaser';
 import { Scene } from 'phaser';
 import { DungeonManager } from '../../engine/DungeonManager.js';
-import { SizingManager } from '../../engine/SizingManager.js';
 
 export class WorldMap extends Scene
 {
@@ -11,7 +10,7 @@ export class WorldMap extends Scene
         this.dungeonManager = null;
         this.commander = null;
         this.cursors = null;
-        this.tileSize = SizingManager.TILE_SIZE;
+        this.tileSize = 0;
         this.isMoving = false;
         this.targetX = null;
         this.targetY = null;
@@ -24,7 +23,11 @@ export class WorldMap extends Scene
 
         this.dungeonManager = new DungeonManager(this, DUNGEON_WIDTH, DUNGEON_HEIGHT, 'wall-tile', 'floor-tile');
         const dungeonTiles = this.dungeonManager.generateDungeon();
-        this.dungeonManager.renderDungeon(this.tileSize);
+
+        const tileTexture = this.textures.get('floor-tile').getSourceImage();
+        this.tileSize = tileTexture.width;
+
+        this.dungeonManager.renderDungeon();
 
         let startX = -1, startY = -1;
         for (let x = 1; x < DUNGEON_WIDTH - 1; x++) {


### PR DESCRIPTION
## Summary
- Render dungeon walls and floors with full tile images instead of 9-slice segments
- Determine tile size from texture dimensions in WorldMap for consistent movement and bounds

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ffbca52c8327b75454fede91b8b9