### PR TITLE
feat: add party engine for player and enemy groups

### DIFF
--- a/src/data/units.js
+++ b/src/data/units.js
@@ -12,5 +12,29 @@ export const UNITS = {
         defense: 5,       // 물리 방어력
         attackSpeed: 1000, // 1초에 한 번 공격
         speed: 200        // 이동 속도
+    },
+
+    GUNNER: {
+        key: 'unit_gunner',
+        name: '거너',
+        image: 'assets/images/unit/gunner.png',
+
+        hp: 80,
+        attack: 12,
+        defense: 3,
+        attackSpeed: 800,
+        speed: 220
+    },
+
+    MEDIC: {
+        key: 'unit_medic',
+        name: '메딕',
+        image: 'assets/images/unit/medic.png',
+
+        hp: 70,
+        attack: 5,
+        defense: 4,
+        attackSpeed: 900,
+        speed: 210
     }
 };

--- a/src/engine/PartyEngine.js
+++ b/src/engine/PartyEngine.js
@@ -1,0 +1,41 @@
+import { Unit } from '../game/Unit.js';
+
+export class PartyEngine {
+    constructor(scene) {
+        this.scene = scene;
+    }
+
+    /**
+     * Create a party of units.
+     * @param {Array<Object>} unitDatas Array of unit data objects from UNITS.
+     * @param {{x:number, y:number}} start Starting grid position of the leader.
+     * @param {{label?: string}} options Additional options.
+     * @returns {Array<Unit>} The created units.
+     */
+    createParty(unitDatas, start, options = {}) {
+        const { label = '' } = options;
+        const formation = [
+            { x: 0, y: 0 },
+            { x: -1, y: 1 },
+            { x: 1, y: 1 },
+            { x: -2, y: 2 },
+            { x: 2, y: 2 }
+        ];
+
+        return unitDatas.map((data, index) => {
+            const offset = { ...(formation[index] || { x: index, y: 0 }) };
+            if (label === '적') {
+                offset.x = -offset.x; // Mirror formation horizontally for enemies
+            }
+            const gridX = start.x + offset.x;
+            const gridY = start.y + offset.y;
+            const name = label ? `${label} ${data.name}` : data.name;
+            const unit = new Unit(this.scene, gridX, gridY, data, name);
+            if (label === '적') {
+                unit.setFlipX(true); // Face left towards the player
+            }
+            return unit;
+        });
+    }
+}
+


### PR DESCRIPTION
## Summary
- create PartyEngine to spawn unit formations
- extend unit data with gunner and medic
- use PartyEngine in BattleScene to spawn mirrored enemy party

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a200c9d0d08327a50c73cb33a1a228