### PR TITLE
feat(worldmap): improve party visuals and camera

### DIFF
--- a/src/engine/SizingManager.js
+++ b/src/engine/SizingManager.js
@@ -5,6 +5,10 @@ export const SizingManager = {
     GRID_HEIGHT: 30,     // 그리드의 세로 타일 수
     TILE_SIZE: 128,      // 각 타일의 한 변 크기 (픽셀)
 
+    // 월드맵 유닛 크기 조절
+    WORLD_UNIT_SCALE: 0.75,     // 일반 유닛이 타일 대비 차지하는 비율
+    WORLD_LEADER_SCALE: 0.9,    // 선봉 유닛이 타일 대비 차지하는 비율
+
     // UI 및 기타 요소
     NAMEPLATE_FONT_SIZE: 32, // 이름표 폰트 크기 (고해상도 기준)
     NAMEPLATE_Y_OFFSET: -55, // 유닛 머리로부터 이름표가 떨어질 거리

--- a/src/game/HealthBar.js
+++ b/src/game/HealthBar.js
@@ -1,0 +1,48 @@
+import { SizingManager } from '../engine/SizingManager.js';
+
+export class HealthBar {
+    /**
+     * @param {Phaser.Scene} scene - 현재 씬
+     * @param {Phaser.GameObjects.GameObject} owner - 체력바가 따라갈 오브젝트
+     */
+    constructor(scene, owner) {
+        this.scene = scene;
+        this.owner = owner;
+        this.width = SizingManager.HEALTHBAR_WIDTH;
+        this.height = SizingManager.HEALTHBAR_HEIGHT;
+        this.offset = SizingManager.HEALTHBAR_Y_OFFSET;
+        this.current = 100;
+        this.max = 100;
+
+        this.renderTexture = scene.add.renderTexture(0, 0, this.width * 2, this.height * 2);
+        this.renderTexture.setScale(0.5);
+        this.renderTexture.setDepth(2);
+        this._draw();
+    }
+
+    _draw() {
+        const g = this.scene.make.graphics({ x: 0, y: 0, add: false });
+        g.clear();
+        g.fillStyle(0x000000, 0.5);
+        g.fillRect(0, 0, this.width * 2, this.height * 2);
+        g.fillStyle(0x00ff00, 1);
+        g.fillRect(0, 0, this.width * 2 * (this.current / this.max), this.height * 2);
+        this.renderTexture.clear();
+        this.renderTexture.draw(g, 0, 0);
+        g.destroy();
+    }
+
+    setHealth(current, max = this.max) {
+        this.current = current;
+        this.max = max;
+        this._draw();
+    }
+
+    update() {
+        this.renderTexture.setPosition(this.owner.x, this.owner.y + this.offset);
+    }
+
+    destroy() {
+        this.renderTexture.destroy();
+    }
+}


### PR DESCRIPTION
## Summary
- Scale world-map units via SizingManager constants
- Render offscreen nameplates and health bars for party members
- Allow deeper camera zoom-out on world map

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2030637708327881406c51ac04fba