### PR TITLE
Add turn engine with debug logging

### DIFF
--- a/src/engine/DebugTurnLogger.js
+++ b/src/engine/DebugTurnLogger.js
@@ -1,0 +1,29 @@
+/**
+ * 이 엔진은 앞으로 턴당 모든 게임의 연산을 개발자 콘솔 로그에 출력해주는 장치이다. 코덱스 나 자신이 후에 이 개발자 콘솔 로그의 로그 기록을 보며 스스로 게임의 오류를 잡아내기 위함이다.
+ */
+export class DebugTurnLogger {
+    static _unitName(unit) {
+        return unit?.label || unit?.name || 'Unknown';
+    }
+
+    static turnStart(turnNumber) {
+        console.groupCollapsed(`--- Turn ${turnNumber} Start ---`);
+    }
+
+    static intent(unit, intent) {
+        console.log(`[Intent] ${this._unitName(unit)}`, intent);
+    }
+
+    static action(action) {
+        console.log(`[Action] ${this._unitName(action.unit)}`, action);
+    }
+
+    static result(unit, result) {
+        console.log(`[Result] ${this._unitName(unit)}`, result);
+    }
+
+    static turnEnd(turnNumber) {
+        console.groupEnd();
+        console.log(`--- Turn ${turnNumber} End ---`);
+    }
+}

--- a/src/game/scenes/BattleScene.js
+++ b/src/game/scenes/BattleScene.js
@@ -1,7 +1,7 @@
 import { Scene } from 'phaser';
 import { UNITS } from '../../data/units.js';
 import { MeleeAI } from '../../ai/meleeAI.js';
-import { TurnManager, TurnState } from '../../engine/TurnManager.js';
+import { TurnEngine, TurnState } from '../../engine/TurnEngine.js';
 import { GridManager } from '../../engine/GridManager.js'; // 그리드 매니저 불러오기
 import { MapManager } from '../../engine/MapManager.js'; // MapManager를 불러옵니다.
 import { PartyEngine } from '../../engine/PartyEngine.js';
@@ -25,7 +25,7 @@ export class BattleScene extends Scene {
         // 1. 매니저들 생성
         this.grid = new GridManager(this);
         this.mapManager = new MapManager(this); // MapManager 인스턴스 생성
-        this.turnManager = new TurnManager(this);
+        this.turnManager = new TurnEngine(this);
 
         // MapManager를 사용하여 맵 타일을 생성합니다.
         this.mapManager.createMap();


### PR DESCRIPTION
## Summary
- add DebugTurnLogger to surface all per-turn calculations in developer console
- refactor turn system into TurnEngine and integrate detailed logging
- update battle scene to leverage new turn engine

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a206c8b3608327b66a7448e11718f4