### PR TITLE
Improve unit formation spacing and UI alignment

### DIFF
--- a/src/engine/PartyEngine.js
+++ b/src/engine/PartyEngine.js
@@ -1,4 +1,5 @@
 import { Unit } from '../game/Unit.js';
+import { SizingManager } from './SizingManager.js';
 
 export class PartyEngine {
     constructor(scene) {
@@ -14,12 +15,13 @@ export class PartyEngine {
      */
     createParty(unitDatas, start, options = {}) {
         const { label = '' } = options;
+        const rowSpacing = 2;
         const formation = [
             { x: 0, y: 0 },
-            { x: -1, y: 1 },
-            { x: 1, y: 1 },
-            { x: -2, y: 2 },
-            { x: 2, y: 2 }
+            { x: -1, y: rowSpacing },
+            { x: 1, y: rowSpacing },
+            { x: -2, y: rowSpacing * 2 },
+            { x: 2, y: rowSpacing * 2 }
         ];
 
         return unitDatas.map((data, index) => {
@@ -30,7 +32,10 @@ export class PartyEngine {
             const gridX = start.x + offset.x;
             const gridY = start.y + offset.y;
             const name = label ? `${label} ${data.name}` : data.name;
-            const unit = new Unit(this.scene, gridX, gridY, data, name);
+            const scale = index === 0
+                ? SizingManager.WORLD_LEADER_SCALE
+                : SizingManager.WORLD_UNIT_SCALE;
+            const unit = new Unit(this.scene, gridX, gridY, data, name, { scale });
             if (label === '적') {
                 unit.setFlipX(true); // Face left towards the player
             }

--- a/src/game/Nameplate.js
+++ b/src/game/Nameplate.js
@@ -40,7 +40,11 @@ export class Nameplate {
 
     // 이름표의 위치를 주인(유닛)을 따라가도록 업데이트
     update() {
-        this.renderTexture.setPosition(this.owner.x, this.owner.y + SizingManager.NAMEPLATE_Y_OFFSET);
+        const topY = this.owner.y - this.owner.displayHeight / 2;
+        this.renderTexture.setPosition(
+            this.owner.x,
+            topY + SizingManager.NAMEPLATE_Y_OFFSET
+        );
     }
 
     // 유닛이 파괴될 때 이름표도 함께 파괴

--- a/src/game/Unit.js
+++ b/src/game/Unit.js
@@ -3,27 +3,30 @@ import { Nameplate } from './Nameplate.js';
 import { SizingManager } from '../engine/SizingManager.js';
 
 export class Unit extends Physics.Arcade.Sprite {
-    constructor(scene, gridX, gridY, unitData, name) {
+    constructor(scene, gridX, gridY, unitData, name, options = {}) {
+        const { scale = 1 } = options;
+
         // 그리드 좌표를 실제 화면 좌표로 변환하여 생성
         const worldPos = scene.grid.getWorldPosition(gridX, gridY);
         super(scene, worldPos.x, worldPos.y, unitData.key);
-        
+
         // --- 유닛의 그리드 위치 저장 ---
         this.gridPosition = { x: gridX, y: gridY };
 
         scene.add.existing(this);
         scene.physics.add.existing(this);
 
-        // ✨ --- 이 부분을 추가하세요! --- ✨
-        // SizingManager에서 정의한 TILE_SIZE에 맞게 유닛의 표시 크기를 조절합니다.
-        this.setDisplaySize(SizingManager.TILE_SIZE, SizingManager.TILE_SIZE);
-        // ✨ --------------------------- ✨
+        // SizingManager에서 정의한 TILE_SIZE와 스케일에 맞게 유닛의 표시 크기를 조절
+        this.setDisplaySize(
+            SizingManager.TILE_SIZE * scale,
+            SizingManager.TILE_SIZE * scale
+        );
 
         this.stats = { ...unitData };
         this.nameplate = new Nameplate(scene, this, name);
         this.healthBar = scene.add.graphics();
         this.updateHealthBar();
-        
+
         this.setDepth(1);
         this.healthBar.setDepth(2);
         this.nameplate.renderTexture.setDepth(3);
@@ -62,14 +65,16 @@ export class Unit extends Physics.Arcade.Sprite {
     // preUpdate에서 이름표, 체력바 위치 업데이트
     preUpdate(time, delta) {
         super.preUpdate(time, delta);
-        const interpolatedPos = this.getCenter(); // Tween 중인 현재 위치를 가져옴
-        // SizingManager에서 Y 오프셋 가져오기
+        const interpolatedPos = this.getCenter();
+        const topY = interpolatedPos.y - this.displayHeight / 2;
+
         this.healthBar.setPosition(
             interpolatedPos.x,
-            interpolatedPos.y + SizingManager.HEALTHBAR_Y_OFFSET
+            topY + SizingManager.HEALTHBAR_Y_OFFSET
         );
+
         if (this.nameplate) {
-            this.nameplate.update(); // Nameplate가 스스로 위치를 업데이트하도록 둡니다.
+            this.nameplate.update();
         }
     }
 


### PR DESCRIPTION
## Summary
- space party formation rows to avoid sprite overlap
- scale leader and unit sprites differently using SizingManager constants
- anchor health bars and nameplates above each unit's head

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2085d94ac8327829557f22a1e36c9