### PR TITLE
feat: add pathfinding and vision systems

### DIFF
--- a/src/ai/BehaviorTree.js
+++ b/src/ai/BehaviorTree.js
@@ -1,0 +1,60 @@
+export const NodeStatus = {
+    SUCCESS: 'SUCCESS',
+    FAILURE: 'FAILURE',
+    RUNNING: 'RUNNING'
+};
+
+class BTNode {
+    tick(blackboard) {
+        return { status: NodeStatus.SUCCESS };
+    }
+}
+
+export class Sequence extends BTNode {
+    constructor(children) {
+        super();
+        this.children = children;
+    }
+
+    tick(bb) {
+        let action = null;
+        for (const child of this.children) {
+            const result = child.tick(bb);
+            if (result.status !== NodeStatus.SUCCESS) {
+                return result;
+            }
+            if (result.action) {
+                action = result.action;
+            }
+        }
+        return { status: NodeStatus.SUCCESS, action };
+    }
+}
+
+export class ConditionNode extends BTNode {
+    constructor(fn) {
+        super();
+        this.fn = fn;
+    }
+
+    tick(bb) {
+        return this.fn(bb)
+            ? { status: NodeStatus.SUCCESS }
+            : { status: NodeStatus.FAILURE };
+    }
+}
+
+export class ActionNode extends BTNode {
+    constructor(fn) {
+        super();
+        this.fn = fn;
+    }
+
+    tick(bb) {
+        const action = this.fn(bb);
+        if (action) {
+            return { status: NodeStatus.SUCCESS, action };
+        }
+        return { status: NodeStatus.FAILURE };
+    }
+}

--- a/src/ai/Blackboard.js
+++ b/src/ai/Blackboard.js
@@ -1,0 +1,13 @@
+export class Blackboard {
+    constructor() {
+        this.data = new Map();
+    }
+
+    set(key, value) {
+        this.data.set(key, value);
+    }
+
+    get(key) {
+        return this.data.get(key);
+    }
+}

--- a/src/ai/WorldMeleeAI.js
+++ b/src/ai/WorldMeleeAI.js
@@ -1,0 +1,49 @@
+import { Blackboard } from './Blackboard.js';
+import { Sequence, ConditionNode, ActionNode } from './BehaviorTree.js';
+import { VisionEngine } from '../engine/VisionEngine.js';
+import { PathfindingEngine } from '../engine/PathfindingEngine.js';
+
+export class WorldMeleeAI {
+    constructor(owner, scene) {
+        this.owner = owner;
+        this.scene = scene;
+        this.blackboard = new Blackboard();
+        this.blackboard.set('self', owner);
+        this.blackboard.set('scene', scene);
+
+        this.tree = new Sequence([
+            new ConditionNode(bb => {
+                const self = bb.get('self');
+                const player = bb.get('player');
+                const start = self.getGridPosition();
+                const end = player.getGridPosition();
+                return VisionEngine.hasLineOfSight(scene.dungeonManager.tiles, start, end, 8);
+            }),
+            new ActionNode(bb => {
+                const self = bb.get('self');
+                const player = bb.get('player');
+                const start = self.getGridPosition();
+                const end = player.getGridPosition();
+                const path = PathfindingEngine.findPath(scene.dungeonManager.tiles, start, end);
+                if (path && path.length > 1) {
+                    const next = path[1];
+                    return { type: 'move', target: next };
+                }
+                return null;
+            })
+        ]);
+    }
+
+    decideAction(playerEntity) {
+        this.blackboard.set('player', playerEntity);
+        const result = this.tree.tick(this.blackboard);
+        if (result && result.action) {
+            return {
+                type: 'move',
+                unit: this.owner,
+                targetPosition: result.action.target
+            };
+        }
+        return null;
+    }
+}

--- a/src/engine/PathfindingEngine.js
+++ b/src/engine/PathfindingEngine.js
@@ -1,0 +1,77 @@
+export class PathfindingEngine {
+    static findPath(grid, start, goal) {
+        const cols = grid.length;
+        const rows = grid[0].length;
+        const toKey = (x, y) => `${x},${y}`;
+
+        const open = [];
+        const closed = new Set();
+
+        const startNode = {
+            x: start.x,
+            y: start.y,
+            g: 0,
+            h: Math.abs(goal.x - start.x) + Math.abs(goal.y - start.y),
+            parent: null
+        };
+        startNode.f = startNode.g + startNode.h;
+        open.push(startNode);
+
+        const dirs = [
+            { x: 1, y: 0 },
+            { x: -1, y: 0 },
+            { x: 0, y: 1 },
+            { x: 0, y: -1 }
+        ];
+
+        while (open.length > 0) {
+            open.sort((a, b) => a.f - b.f);
+            const current = open.shift();
+
+            if (current.x === goal.x && current.y === goal.y) {
+                return reconstructPath(current);
+            }
+
+            closed.add(toKey(current.x, current.y));
+
+            for (const dir of dirs) {
+                const nx = current.x + dir.x;
+                const ny = current.y + dir.y;
+
+                if (nx < 0 || ny < 0 || nx >= cols || ny >= rows) {
+                    continue;
+                }
+                if (grid[nx][ny] !== 0) {
+                    continue;
+                }
+                const key = toKey(nx, ny);
+                if (closed.has(key)) {
+                    continue;
+                }
+
+                const g = current.g + 1;
+                const h = Math.abs(goal.x - nx) + Math.abs(goal.y - ny);
+                const node = { x: nx, y: ny, g, h, f: g + h, parent: current };
+                const existing = open.find(n => n.x === nx && n.y === ny);
+                if (!existing) {
+                    open.push(node);
+                } else if (g < existing.g) {
+                    existing.g = g;
+                    existing.f = g + existing.h;
+                    existing.parent = current;
+                }
+            }
+        }
+        return null;
+    }
+}
+
+function reconstructPath(node) {
+    const path = [];
+    let current = node;
+    while (current) {
+        path.unshift({ x: current.x, y: current.y });
+        current = current.parent;
+    }
+    return path;
+}

--- a/src/engine/VisionEngine.js
+++ b/src/engine/VisionEngine.js
@@ -1,0 +1,55 @@
+export class VisionEngine {
+    static hasLineOfSight(grid, start, end, radius = 10) {
+        const dx = end.x - start.x;
+        const dy = end.y - start.y;
+        if (Math.sqrt(dx * dx + dy * dy) > radius) {
+            return false;
+        }
+        const line = bresenham(start.x, start.y, end.x, end.y);
+        for (let i = 1; i < line.length - 1; i++) {
+            const { x, y } = line[i];
+            if (grid[x] && grid[x][y] === 1) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static computeFOV(grid, origin, radius) {
+        const visible = [];
+        for (let x = origin.x - radius; x <= origin.x + radius; x++) {
+            for (let y = origin.y - radius; y <= origin.y + radius; y++) {
+                if (x < 0 || y < 0 || x >= grid.length || y >= grid[0].length) {
+                    continue;
+                }
+                if (this.hasLineOfSight(grid, origin, { x, y }, radius)) {
+                    visible.push({ x, y });
+                }
+            }
+        }
+        return visible;
+    }
+}
+
+function bresenham(x0, y0, x1, y1) {
+    const points = [];
+    const dx = Math.abs(x1 - x0);
+    const dy = -Math.abs(y1 - y0);
+    const sx = x0 < x1 ? 1 : -1;
+    const sy = y0 < y1 ? 1 : -1;
+    let err = dx + dy;
+    while (true) {
+        points.push({ x: x0, y: y0 });
+        if (x0 === x1 && y0 === y1) break;
+        const e2 = 2 * err;
+        if (e2 >= dy) {
+            err += dy;
+            x0 += sx;
+        }
+        if (e2 <= dx) {
+            err += dx;
+            y0 += sy;
+        }
+    }
+    return points;
+}

--- a/src/game/WorldEnemy.js
+++ b/src/game/WorldEnemy.js
@@ -1,0 +1,30 @@
+import { WorldEntity } from './WorldEntity.js';
+import { WorldMeleeAI } from '../ai/WorldMeleeAI.js';
+import { Nameplate } from './Nameplate.js';
+import { HealthBar } from './HealthBar.js';
+
+export class WorldEnemy extends WorldEntity {
+    constructor(scene, gridX, gridY, key, name, tileSize) {
+        const worldX = gridX * tileSize + tileSize / 2;
+        const worldY = gridY * tileSize + tileSize / 2;
+        const container = scene.add.container(worldX, worldY);
+        const sprite = scene.add.sprite(0, 0, key).setDisplaySize(tileSize, tileSize);
+        container.add(sprite);
+
+        const nameplate = new Nameplate(scene, sprite, name);
+        const healthBar = new HealthBar(scene, sprite);
+        container.add(nameplate.renderTexture);
+        container.add(healthBar.renderTexture);
+
+        super(scene, container, tileSize);
+        this.sprite = sprite;
+        this.nameplate = nameplate;
+        this.healthBar = healthBar;
+        this.ai = new WorldMeleeAI(this, scene);
+    }
+
+    update() {
+        if (this.nameplate) this.nameplate.update();
+        if (this.healthBar) this.healthBar.update();
+    }
+}

--- a/src/game/WorldEntity.js
+++ b/src/game/WorldEntity.js
@@ -1,0 +1,27 @@
+export class WorldEntity {
+    constructor(scene, container, tileSize) {
+        this.scene = scene;
+        this.container = container;
+        this.tileSize = tileSize;
+    }
+
+    getGridPosition() {
+        return {
+            x: Math.floor(this.container.x / this.tileSize),
+            y: Math.floor(this.container.y / this.tileSize)
+        };
+    }
+
+    moveToTile(gridX, gridY, onComplete) {
+        const targetX = gridX * this.tileSize + this.tileSize / 2;
+        const targetY = gridY * this.tileSize + this.tileSize / 2;
+        this.scene.tweens.add({
+            targets: this.container,
+            x: targetX,
+            y: targetY,
+            duration: 200,
+            ease: 'Power2',
+            onComplete
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add modular A* pathfinding and simple vision engine
- introduce lightweight behavior tree framework with blackboard
- spawn enemy party on world map that chases the player each turn

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a20bc7116c8327b5c3b45cf2a08703