### PR TITLE
feat: simplify world map to single warrior

### DIFF
--- a/src/game/WorldEnemy.js
+++ b/src/game/WorldEnemy.js
@@ -8,7 +8,9 @@ export class WorldEnemy extends WorldEntity {
         const worldX = gridX * tileSize + tileSize / 2;
         const worldY = gridY * tileSize + tileSize / 2;
         const container = scene.add.container(worldX, worldY);
-        const sprite = scene.add.sprite(0, 0, key).setDisplaySize(tileSize, tileSize);
+        const sprite = scene.add.sprite(0, 0, key)
+            .setDisplaySize(tileSize, tileSize)
+            .setFlipX(true);
         container.add(sprite);
 
         const nameplate = new Nameplate(scene, sprite, name);


### PR DESCRIPTION
## Summary
- collapse player party on the world map into one warrior scaled to full tile size
- spawn a single pursuing enemy warrior and mirror its sprite horizontally

## Testing
- ⚠️ `npm test` (missing script: test)
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a210c04a748327b2a0a952185eefe8