### PR TITLE
feat: add ranged and healer AI

### DIFF
--- a/src/ai/HealerAI.js
+++ b/src/ai/HealerAI.js
@@ -1,0 +1,50 @@
+// 아군을 지원하며 적과 거리를 유지하는 AI
+export class HealerAI {
+    constructor(owner, allies) {
+        this.owner = owner;
+        this.allies = allies;
+    }
+
+    decideAction(enemy) {
+        const ownerPos = this.owner.gridPosition;
+        const range = this.owner.stats.range || 1;
+
+        // 치유가 필요한 아군 찾기
+        const targets = this.allies.filter(u => u !== this.owner && u.stats.hp < u.stats.maxHp);
+        targets.sort((a, b) => a.stats.hp - b.stats.hp);
+        const healTarget = targets[0];
+
+        if (healTarget) {
+            const hx = healTarget.gridPosition.x - ownerPos.x;
+            const hy = healTarget.gridPosition.y - ownerPos.y;
+            const healDist = Math.abs(hx) + Math.abs(hy);
+            if (healDist <= range) {
+                return { type: 'heal', unit: this.owner, target: healTarget };
+            }
+            let nextX = ownerPos.x;
+            let nextY = ownerPos.y;
+            if (hx < 0) nextX--; else if (hx > 0) nextX++;
+            else if (hy < 0) nextY--; else if (hy > 0) nextY++;
+            if (nextX !== ownerPos.x || nextY !== ownerPos.y) {
+                return { type: 'move', unit: this.owner, targetPosition: { x: nextX, y: nextY } };
+            }
+        }
+
+        // 적과의 거리 유지
+        if (enemy) {
+            const ex = enemy.gridPosition.x - ownerPos.x;
+            const ey = enemy.gridPosition.y - ownerPos.y;
+            const enemyDist = Math.abs(ex) + Math.abs(ey);
+            if (enemyDist < range) {
+                let nextX = ownerPos.x;
+                let nextY = ownerPos.y;
+                if (Math.abs(ex) > Math.abs(ey)) nextX -= Math.sign(ex);
+                else nextY -= Math.sign(ey);
+                if (nextX !== ownerPos.x || nextY !== ownerPos.y) {
+                    return { type: 'move', unit: this.owner, targetPosition: { x: nextX, y: nextY } };
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/ai/RangedAI.js
+++ b/src/ai/RangedAI.js
@@ -1,10 +1,9 @@
-// AI가 행동을 결정하는 클래스
-export class MeleeAI {
+// 원거리 유닛이 거리를 유지하며 공격하는 AI
+export class RangedAI {
     constructor(owner) {
-        this.owner = owner; // 이 AI의 주인
+        this.owner = owner;
     }
 
-    // 어떤 행동을 할지 결정해서 반환
     decideAction(target) {
         const ownerPos = this.owner.gridPosition;
         const targetPos = target.gridPosition;
@@ -13,7 +12,7 @@ export class MeleeAI {
         const distance = Math.abs(dx) + Math.abs(dy);
         const range = this.owner.stats.range || 1;
 
-        if (distance <= range) {
+        if (distance === range) {
             return {
                 type: 'attack',
                 unit: this.owner,
@@ -24,10 +23,15 @@ export class MeleeAI {
         let nextX = ownerPos.x;
         let nextY = ownerPos.y;
 
-        if (dx < 0) nextX--;
-        else if (dx > 0) nextX++;
-        else if (dy < 0) nextY--;
-        else if (dy > 0) nextY++;
+        if (distance > range) {
+            if (dx < 0) nextX--;
+            else if (dx > 0) nextX++;
+            else if (dy < 0) nextY--;
+            else if (dy > 0) nextY++;
+        } else {
+            if (Math.abs(dx) > Math.abs(dy)) nextX -= Math.sign(dx);
+            else nextY -= Math.sign(dy);
+        }
 
         if (nextX !== ownerPos.x || nextY !== ownerPos.y) {
             return {
@@ -37,7 +41,6 @@ export class MeleeAI {
             };
         }
 
-        return null; // 움직일 필요가 없으면 아무 행동도 안함
+        return null;
     }
 }
-

--- a/src/data/units.js
+++ b/src/data/units.js
@@ -11,7 +11,9 @@ export const UNITS = {
         attack: 10,       // 물리 공격력
         defense: 5,       // 물리 방어력
         attackSpeed: 1000, // 1초에 한 번 공격
-        speed: 200        // 이동 속도
+        speed: 200,        // 이동 속도
+        range: 1,
+        ability: 'melee'
     },
 
     GUNNER: {
@@ -23,7 +25,9 @@ export const UNITS = {
         attack: 12,
         defense: 3,
         attackSpeed: 800,
-        speed: 220
+        speed: 220,
+        range: 3,
+        ability: 'ranged'
     },
 
     MEDIC: {
@@ -35,6 +39,8 @@ export const UNITS = {
         attack: 5,
         defense: 4,
         attackSpeed: 900,
-        speed: 210
+        speed: 210,
+        range: 2,
+        ability: 'heal'
     }
 };

--- a/src/game/scenes/BattleScene.js
+++ b/src/game/scenes/BattleScene.js
@@ -1,6 +1,8 @@
 import { Scene } from 'phaser';
 import { UNITS } from '../../data/units.js';
 import { MeleeAI } from '../../ai/meleeAI.js';
+import { RangedAI } from '../../ai/RangedAI.js';
+import { HealerAI } from '../../ai/HealerAI.js';
 import { TurnEngine, TurnState } from '../../engine/TurnEngine.js';
 import { GridManager } from '../../engine/GridManager.js'; // 그리드 매니저 불러오기
 import { MapManager } from '../../engine/MapManager.js'; // MapManager를 불러옵니다.
@@ -55,7 +57,13 @@ export class BattleScene extends Scene {
         );
         this.enemies = this.enemyParty;
         this.enemyParty.forEach(enemy => {
-            enemy.ai = new MeleeAI(enemy);
+            if (enemy.stats.ability === 'melee') {
+                enemy.ai = new MeleeAI(enemy);
+            } else if (enemy.stats.ability === 'ranged') {
+                enemy.ai = new RangedAI(enemy);
+            } else if (enemy.stats.ability === 'heal') {
+                enemy.ai = new HealerAI(enemy, this.enemyParty);
+            }
         });
 
         // 3. 입력 및 기타 설정


### PR DESCRIPTION
## Summary
- add range and ability stats for warrior, gunner, medic
- implement melee, ranged, and healer AI behaviors
- enable attack and heal actions during battle

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a213336ab083278eafa4b40befa3e8